### PR TITLE
feat: smart calculators, running tape, and exploratory-testing fixes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
             android:exported="true"
             android:launchMode="singleTop"
             android:taskAffinity=""
+            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="@color/launch_background" />
 </layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="@color/launch_background" />
 </layer-list>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -13,6 +13,6 @@
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
-        <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowBackground">@color/launch_background</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Matches AppPalette.dark.background (#0E0E0E). The app ships dark by
+         default, so the launch window uses it in both OS modes rather than
+         flashing white before the first Flutter frame. -->
+    <color name="launch_background">#FF0E0E0E</color>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -9,10 +9,8 @@
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
          Flutter UI initializes, as well as behind your Flutter UI while its
-         running.
-
-         This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <item name="android:windowBackground">?android:colorBackground</item>
+         running. -->
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">@color/launch_background</item>
     </style>
 </resources>

--- a/lib/app/layout.dart
+++ b/lib/app/layout.dart
@@ -1,0 +1,11 @@
+/// Shared layout metrics for the app shell.
+library;
+
+/// Height of the floating bottom nav pill.
+const double kFloatingNavHeight = 64;
+
+/// Gap between the nav pill and the bottom of the screen.
+const double kFloatingNavInset = 16;
+
+/// Vertical space screens must reserve so content never sits under the nav.
+const double kFloatingNavReserved = kFloatingNavHeight + kFloatingNavInset;

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,144 +1,308 @@
 import 'package:flutter/material.dart';
+// SystemUiOverlayStyle is not re-exported by material.dart.
+import 'package:flutter/services.dart' show SystemUiOverlayStyle;
 import 'package:google_fonts/google_fonts.dart';
 
-/// Calculus Dark — "The Obsidian Architect"
-/// Primary: #a8a4ff Electric Indigo, bg: #0e0e0e The Void
+/// Every surface/accent colour the app paints, resolved per brightness.
+///
+/// Widgets read these through `context.palette` rather than referencing raw
+/// constants, so a theme switch actually repaints the UI.
+@immutable
+class AppPalette extends ThemeExtension<AppPalette> {
+  final Color background;
+  final Color surfaceContainerLowest;
+  final Color surfaceContainerLow;
+  final Color surfaceContainer;
+  final Color surfaceContainerHigh;
+  final Color surfaceContainerHighest;
+
+  final Color primary;
+  final Color primaryDim;
+  final Color onPrimary;
+
+  final Color onSurface;
+  final Color onSurfaceVariant;
+
+  final Color error;
+  final Color errorContainer;
+  final Color green;
+  final Color greenDark;
+  final Color pinned;
+
+  // Keypad
+  final Color btnNumber;
+  final Color btnOperator;
+  final Color btnClear;
+  final Color btnFunction;
+
+  const AppPalette({
+    required this.background,
+    required this.surfaceContainerLowest,
+    required this.surfaceContainerLow,
+    required this.surfaceContainer,
+    required this.surfaceContainerHigh,
+    required this.surfaceContainerHighest,
+    required this.primary,
+    required this.primaryDim,
+    required this.onPrimary,
+    required this.onSurface,
+    required this.onSurfaceVariant,
+    required this.error,
+    required this.errorContainer,
+    required this.green,
+    required this.greenDark,
+    required this.pinned,
+    required this.btnNumber,
+    required this.btnOperator,
+    required this.btnClear,
+    required this.btnFunction,
+  });
+
+  /// Calculus Dark — "The Obsidian Architect"
+  static const AppPalette dark = AppPalette(
+    background: Color(0xFF0E0E0E),
+    surfaceContainerLowest: Color(0xFF000000),
+    surfaceContainerLow: Color(0xFF131313),
+    surfaceContainer: Color(0xFF1A1919),
+    surfaceContainerHigh: Color(0xFF201F1F),
+    surfaceContainerHighest: Color(0xFF262626),
+    primary: Color(0xFFA8A4FF),
+    primaryDim: Color(0xFF675DF9),
+    onPrimary: Color(0xFF1E009F),
+    onSurface: Color(0xFFFFFFFF),
+    onSurfaceVariant: Color(0xFFADAAAA),
+    error: Color(0xFFFF6E84),
+    errorContainer: Color(0xFF3D1515),
+    green: Color(0xFF00C853),
+    greenDark: Color(0xFF069E46),
+    pinned: Color(0xFFFFD600),
+    // Numbers sit above the keypad, operators sink below it.
+    btnNumber: Color(0xFF201F1F),
+    btnOperator: Color(0xFF000000),
+    btnClear: Color(0xFF3D1515),
+    btnFunction: Color(0xFF1A1919),
+  );
+
+  /// Calculus Light — same geometry, inverted depth.
+  static const AppPalette light = AppPalette(
+    background: Color(0xFFFAF9FB),
+    surfaceContainerLowest: Color(0xFFFFFFFF),
+    surfaceContainerLow: Color(0xFFF5F3F7),
+    surfaceContainer: Color(0xFFF1EFF4),
+    surfaceContainerHigh: Color(0xFFEAE7EF),
+    surfaceContainerHighest: Color(0xFFE2DEE9),
+    primary: Color(0xFF5B4CE0),
+    primaryDim: Color(0xFF4436C4),
+    onPrimary: Color(0xFFFFFFFF),
+    onSurface: Color(0xFF16151A),
+    onSurfaceVariant: Color(0xFF5D5A66),
+    error: Color(0xFFC0263C),
+    errorContainer: Color(0xFFFBE0E4),
+    green: Color(0xFF0A7A3D),
+    greenDark: Color(0xFF06612F),
+    pinned: Color(0xFFB98900),
+    btnNumber: Color(0xFFFFFFFF),
+    btnOperator: Color(0xFFE2DEE9),
+    btnClear: Color(0xFFFBE0E4),
+    btnFunction: Color(0xFFF1EFF4),
+  );
+
+  @override
+  AppPalette copyWith({
+    Color? background,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
+    Color? primary,
+    Color? primaryDim,
+    Color? onPrimary,
+    Color? onSurface,
+    Color? onSurfaceVariant,
+    Color? error,
+    Color? errorContainer,
+    Color? green,
+    Color? greenDark,
+    Color? pinned,
+    Color? btnNumber,
+    Color? btnOperator,
+    Color? btnClear,
+    Color? btnFunction,
+  }) {
+    return AppPalette(
+      background: background ?? this.background,
+      surfaceContainerLowest:
+          surfaceContainerLowest ?? this.surfaceContainerLowest,
+      surfaceContainerLow: surfaceContainerLow ?? this.surfaceContainerLow,
+      surfaceContainer: surfaceContainer ?? this.surfaceContainer,
+      surfaceContainerHigh: surfaceContainerHigh ?? this.surfaceContainerHigh,
+      surfaceContainerHighest:
+          surfaceContainerHighest ?? this.surfaceContainerHighest,
+      primary: primary ?? this.primary,
+      primaryDim: primaryDim ?? this.primaryDim,
+      onPrimary: onPrimary ?? this.onPrimary,
+      onSurface: onSurface ?? this.onSurface,
+      onSurfaceVariant: onSurfaceVariant ?? this.onSurfaceVariant,
+      error: error ?? this.error,
+      errorContainer: errorContainer ?? this.errorContainer,
+      green: green ?? this.green,
+      greenDark: greenDark ?? this.greenDark,
+      pinned: pinned ?? this.pinned,
+      btnNumber: btnNumber ?? this.btnNumber,
+      btnOperator: btnOperator ?? this.btnOperator,
+      btnClear: btnClear ?? this.btnClear,
+      btnFunction: btnFunction ?? this.btnFunction,
+    );
+  }
+
+  @override
+  AppPalette lerp(ThemeExtension<AppPalette>? other, double t) {
+    if (other is! AppPalette) return this;
+    Color c(Color a, Color b) => Color.lerp(a, b, t)!;
+    return AppPalette(
+      background: c(background, other.background),
+      surfaceContainerLowest:
+          c(surfaceContainerLowest, other.surfaceContainerLowest),
+      surfaceContainerLow: c(surfaceContainerLow, other.surfaceContainerLow),
+      surfaceContainer: c(surfaceContainer, other.surfaceContainer),
+      surfaceContainerHigh: c(surfaceContainerHigh, other.surfaceContainerHigh),
+      surfaceContainerHighest:
+          c(surfaceContainerHighest, other.surfaceContainerHighest),
+      primary: c(primary, other.primary),
+      primaryDim: c(primaryDim, other.primaryDim),
+      onPrimary: c(onPrimary, other.onPrimary),
+      onSurface: c(onSurface, other.onSurface),
+      onSurfaceVariant: c(onSurfaceVariant, other.onSurfaceVariant),
+      error: c(error, other.error),
+      errorContainer: c(errorContainer, other.errorContainer),
+      green: c(green, other.green),
+      greenDark: c(greenDark, other.greenDark),
+      pinned: c(pinned, other.pinned),
+      btnNumber: c(btnNumber, other.btnNumber),
+      btnOperator: c(btnOperator, other.btnOperator),
+      btnClear: c(btnClear, other.btnClear),
+      btnFunction: c(btnFunction, other.btnFunction),
+    );
+  }
+}
+
+/// `context.palette` — the only way widgets should reach for colour.
+extension PaletteContext on BuildContext {
+  AppPalette get palette =>
+      Theme.of(this).extension<AppPalette>() ?? AppPalette.dark;
+}
+
 class AppTheme {
-  // ── Palette ────────────────────────────────────────────────────────────────
-  static const Color background = Color(0xFF0E0E0E);
-  static const Color surfaceContainerLow = Color(0xFF131313);
-  static const Color surfaceContainer = Color(0xFF1A1919);
-  static const Color surfaceContainerHigh = Color(0xFF201F1F);
-  static const Color surfaceContainerHighest = Color(0xFF262626);
-  static const Color surfaceContainerLowest = Color(0xFF000000);
+  const AppTheme._();
 
-  static const Color primary = Color(0xFFa8a4ff);
-  static const Color primaryDim = Color(0xFF675df9);
-  static const Color onPrimary = Color(0xFF1e009f);
+  static ThemeData get darkTheme => _buildTheme(AppPalette.dark);
+  static ThemeData get lightTheme => _buildTheme(AppPalette.light);
 
-  static const Color onSurface = Color(0xFFFFFFFF);
-  static const Color onSurfaceVariant = Color(0xFFadaaaa);
-
-  static const Color error = Color(0xFFff6e84);
-  static const Color errorContainer = Color(0xFF3D1515);
-
-  // Button-specific
-  static const Color btnNumber = surfaceContainerHigh;     // #201f1f
-  static const Color btnOperator = surfaceContainerLowest; // #000
-  static const Color btnClear = errorContainer;            // red tinted
-  static const Color btnFunction = surfaceContainer;       // #1a1919
-
-  static const Color indigo = primary;
-  static const Color green = Color(0xFF00C853);
-  static const Color greenDark = Color(0xFF069E46);
-
-  // ── Typography ─────────────────────────────────────────────────────────────
-  static TextTheme _buildTextTheme() {
+  static TextTheme _buildTextTheme(AppPalette p) {
     final spaceGrotesk = GoogleFonts.spaceGroteskTextTheme();
     final manrope = GoogleFonts.manropeTextTheme();
     return TextTheme(
       // Display — Space Grotesk (numbers, heroes)
       displayLarge: spaceGrotesk.displayLarge?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w300,
         letterSpacing: -1.5,
       ),
       displayMedium: spaceGrotesk.displayMedium?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w300,
         letterSpacing: -0.5,
       ),
       displaySmall: spaceGrotesk.displaySmall?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w400,
       ),
       // Headlines — Space Grotesk
-      headlineLarge: spaceGrotesk.headlineLarge?.copyWith(color: onSurface),
-      headlineMedium: spaceGrotesk.headlineMedium?.copyWith(color: onSurface),
-      headlineSmall: spaceGrotesk.headlineSmall?.copyWith(color: onSurface),
+      headlineLarge: spaceGrotesk.headlineLarge?.copyWith(color: p.onSurface),
+      headlineMedium: spaceGrotesk.headlineMedium?.copyWith(color: p.onSurface),
+      headlineSmall: spaceGrotesk.headlineSmall?.copyWith(color: p.onSurface),
       // Titles — Space Grotesk
       titleLarge: spaceGrotesk.titleLarge?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w600,
       ),
       titleMedium: spaceGrotesk.titleMedium?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w600,
       ),
-      titleSmall: spaceGrotesk.titleSmall?.copyWith(color: onSurface),
+      titleSmall: spaceGrotesk.titleSmall?.copyWith(color: p.onSurface),
       // Body — Manrope
-      bodyLarge: manrope.bodyLarge?.copyWith(color: onSurface),
-      bodyMedium: manrope.bodyMedium?.copyWith(color: onSurfaceVariant),
-      bodySmall: manrope.bodySmall?.copyWith(color: onSurfaceVariant),
+      bodyLarge: manrope.bodyLarge?.copyWith(color: p.onSurface),
+      bodyMedium: manrope.bodyMedium?.copyWith(color: p.onSurfaceVariant),
+      bodySmall: manrope.bodySmall?.copyWith(color: p.onSurfaceVariant),
       // Labels — Manrope
       labelLarge: manrope.labelLarge?.copyWith(
-        color: onSurface,
+        color: p.onSurface,
         fontWeight: FontWeight.w600,
       ),
-      labelMedium: manrope.labelMedium?.copyWith(color: onSurfaceVariant),
+      labelMedium: manrope.labelMedium?.copyWith(color: p.onSurfaceVariant),
       labelSmall: manrope.labelSmall?.copyWith(
-        color: onSurfaceVariant,
+        color: p.onSurfaceVariant,
         letterSpacing: 1.2,
       ),
     );
   }
 
-  // ── Single dark theme (Calculus Dark is always dark) ───────────────────────
-  static ThemeData get darkTheme => _buildTheme(Brightness.dark);
+  static ThemeData _buildTheme(AppPalette p) {
+    final isDark = p == AppPalette.dark;
+    final brightness = isDark ? Brightness.dark : Brightness.light;
 
-  // Light theme kept for theme-toggle compatibility — uses same palette
-  // with a lighter surface tint but keeps the indigo accent
-  static ThemeData get lightTheme => _buildTheme(Brightness.light);
+    final cs = ColorScheme(
+      brightness: brightness,
+      primary: p.primary,
+      onPrimary: p.onPrimary,
+      secondary: p.primaryDim,
+      onSecondary: p.onPrimary,
+      surface: p.background,
+      onSurface: p.onSurface,
+      onSurfaceVariant: p.onSurfaceVariant,
+      error: p.error,
+      onError: isDark ? const Color(0xFF3D1515) : Colors.white,
+      outline: p.onSurfaceVariant,
+      outlineVariant: p.surfaceContainerHighest,
+      surfaceContainerLowest: p.surfaceContainerLowest,
+      surfaceContainerLow: p.surfaceContainerLow,
+      surfaceContainer: p.surfaceContainer,
+      surfaceContainerHigh: p.surfaceContainerHigh,
+      surfaceContainerHighest: p.surfaceContainerHighest,
+    );
 
-  static ThemeData _buildTheme(Brightness brightness) {
-    final isDark = brightness == Brightness.dark;
-
-    final cs = isDark
-        ? const ColorScheme.dark(
-            primary: primary,
-            onPrimary: onPrimary,
-            secondary: Color(0xFFe5e2e1),
-            onSecondary: Color(0xFF403f3f),
-            surface: background,
-            onSurface: onSurface,
-            onSurfaceVariant: onSurfaceVariant,
-            error: error,
-            outline: Color(0xFF767575),
-            outlineVariant: Color(0xFF484847),
-            surfaceContainerLowest: surfaceContainerLowest,
-            surfaceContainerLow: surfaceContainerLow,
-            surfaceContainer: surfaceContainer,
-            surfaceContainerHigh: surfaceContainerHigh,
-            surfaceContainerHighest: surfaceContainerHighest,
-          )
-        : const ColorScheme.light(
-            primary: primary,
-            onPrimary: Colors.white,
-            secondary: Color(0xFF474746),
-            surface: Color(0xFF1a1919),
-            onSurface: onSurface,
-            onSurfaceVariant: onSurfaceVariant,
-            error: error,
-          );
-
-    final tt = _buildTextTheme();
+    final tt = _buildTextTheme(p);
 
     return ThemeData(
       useMaterial3: true,
       brightness: brightness,
       colorScheme: cs,
       textTheme: tt,
-      scaffoldBackgroundColor: background,
+      scaffoldBackgroundColor: p.background,
+      extensions: <ThemeExtension<dynamic>>[p],
       appBarTheme: AppBarTheme(
         elevation: 0,
         backgroundColor: Colors.transparent,
-        foregroundColor: onSurface,
+        foregroundColor: p.onSurface,
         centerTitle: true,
         titleTextStyle: tt.titleMedium,
+        // Without this the status bar keeps white glyphs over the light
+        // background and the clock becomes unreadable.
+        systemOverlayStyle: SystemUiOverlayStyle(
+          statusBarColor: Colors.transparent,
+          statusBarIconBrightness:
+              isDark ? Brightness.light : Brightness.dark,
+          statusBarBrightness: isDark ? Brightness.dark : Brightness.light,
+          systemNavigationBarColor: p.background,
+          systemNavigationBarIconBrightness:
+              isDark ? Brightness.light : Brightness.dark,
+        ),
       ),
       cardTheme: CardThemeData(
         elevation: 0,
-        color: surfaceContainerLow,
+        color: p.surfaceContainerLow,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(24),
         ),
@@ -146,7 +310,7 @@ class AppTheme {
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: surfaceContainerHigh,
+        fillColor: p.surfaceContainerHigh,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(16),
           borderSide: BorderSide.none,
@@ -157,24 +321,16 @@ class AppTheme {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(16),
-          borderSide: const BorderSide(color: primary, width: 1.5),
+          borderSide: BorderSide(color: p.primary, width: 1.5),
         ),
-        labelStyle: const TextStyle(color: onSurfaceVariant),
-        hintStyle: const TextStyle(color: onSurfaceVariant),
+        labelStyle: TextStyle(color: p.onSurfaceVariant),
+        hintStyle: TextStyle(color: p.onSurfaceVariant),
         contentPadding:
             const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
       ),
-      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        selectedItemColor: primary,
-        unselectedItemColor: onSurfaceVariant,
-        showSelectedLabels: true,
-        showUnselectedLabels: true,
-        type: BottomNavigationBarType.fixed,
-      ),
       dividerTheme: const DividerThemeData(color: Colors.transparent),
-      iconTheme: const IconThemeData(color: onSurfaceVariant),
+      iconTheme: IconThemeData(color: p.onSurfaceVariant),
+      progressIndicatorTheme: ProgressIndicatorThemeData(color: p.primary),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,10 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'app/layout.dart';
 import 'app/theme.dart';
 import 'providers/history_provider.dart';
+import 'providers/shell_provider.dart';
 import 'screens/calculator_screen.dart';
 import 'screens/history_screen.dart';
 import 'screens/smart_calculators_screen.dart';
@@ -55,6 +57,7 @@ class LifeMathematicsAppState extends State<LifeMathematicsApp> {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => HistoryProvider()),
+        ChangeNotifierProvider(create: (_) => ShellProvider()),
       ],
       child: MaterialApp(
         title: 'Life Mathematics',
@@ -68,15 +71,8 @@ class LifeMathematicsAppState extends State<LifeMathematicsApp> {
   }
 }
 
-class HomePage extends StatefulWidget {
+class HomePage extends StatelessWidget {
   const HomePage({super.key});
-
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage> {
-  int _selectedIndex = 0;
 
   static const List<Widget> _screens = [
     CalculatorScreen(),
@@ -93,10 +89,12 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     final appState = LifeMathematicsApp.of(context);
+    final palette = context.palette;
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final shell = context.watch<ShellProvider>();
 
     return Scaffold(
-      backgroundColor: AppTheme.background,
+      backgroundColor: palette.background,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
@@ -106,49 +104,61 @@ class _HomePageState extends State<HomePage> {
           style: GoogleFonts.manrope(
             fontSize: 18,
             fontWeight: FontWeight.w600,
-            color: AppTheme.onSurface,
+            color: palette.onSurface,
           ),
         ),
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12),
-            child: GestureDetector(
-              onTap: () => appState?.toggleTheme(),
-              child: Container(
-                width: 40,
-                height: 40,
-                decoration: const BoxDecoration(
-                  color: AppTheme.surfaceContainerHigh,
-                  shape: BoxShape.circle,
-                ),
-                child: Icon(
-                  isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
-                  size: 20,
-                  color: AppTheme.onSurfaceVariant,
+            child: Semantics(
+              button: true,
+              label: isDark ? 'Switch to light theme' : 'Switch to dark theme',
+              child: GestureDetector(
+                onTap: () => appState?.toggleTheme(),
+                child: Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: palette.surfaceContainerHigh,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    isDark
+                        ? Icons.light_mode_outlined
+                        : Icons.dark_mode_outlined,
+                    size: 20,
+                    color: palette.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
           ),
         ],
       ),
-      // No bottomNavigationBar — we use a Stack overlay instead
+      // No bottomNavigationBar — a Stack overlay lets the keypad run behind
+      // the frosted nav. StackFit.expand is load-bearing: without it the Stack
+      // shrink-wraps a short scrolling child and the nav floats mid-screen.
       body: Stack(
+        fit: StackFit.expand,
         children: [
-          // Screen content with bottom padding for the nav bar
+          // IndexedStack keeps every tab alive, so leaving the calculator no
+          // longer throws away the running calculation.
           Padding(
-            padding: const EdgeInsets.only(bottom: 80),
-            child: _screens[_selectedIndex],
+            padding: const EdgeInsets.only(bottom: kFloatingNavReserved),
+            child: IndexedStack(
+              index: shell.index,
+              children: _screens,
+            ),
           ),
 
-          // Floating frosted glass bottom nav
           Positioned(
             left: 16,
             right: 16,
-            bottom: 16,
+            bottom: kFloatingNavInset,
             child: _FloatingNav(
-              selectedIndex: _selectedIndex,
+              selectedIndex: shell.index,
               items: _navItems,
-              onTap: (i) => setState(() => _selectedIndex = i),
+              onTap: context.read<ShellProvider>().setIndex,
             ),
           ),
         ],
@@ -170,14 +180,15 @@ class _FloatingNav extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     return ClipRRect(
       borderRadius: BorderRadius.circular(32),
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
         child: Container(
-          height: 64,
+          height: kFloatingNavHeight,
           decoration: BoxDecoration(
-            color: AppTheme.surfaceContainerHighest.withValues(alpha: 0.85),
+            color: palette.surfaceContainerHighest.withValues(alpha: 0.85),
             borderRadius: BorderRadius.circular(32),
           ),
           child: Row(
@@ -185,44 +196,48 @@ class _FloatingNav extends StatelessWidget {
               final item = items[i];
               final isActive = i == selectedIndex;
               return Expanded(
-                child: GestureDetector(
-                  onTap: () => onTap(i),
-                  behavior: HitTestBehavior.opaque,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        item.icon,
-                        size: 22,
-                        color: isActive
-                            ? AppTheme.primary
-                            : AppTheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        item.label,
-                        style: GoogleFonts.manrope(
-                          fontSize: 10,
-                          fontWeight: isActive
-                              ? FontWeight.w600
-                              : FontWeight.w400,
+                child: Semantics(
+                  button: true,
+                  selected: isActive,
+                  label: item.label,
+                  child: GestureDetector(
+                    onTap: () => onTap(i),
+                    behavior: HitTestBehavior.opaque,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          item.icon,
+                          size: 22,
                           color: isActive
-                              ? AppTheme.primary
-                              : AppTheme.onSurfaceVariant,
+                              ? palette.primary
+                              : palette.onSurfaceVariant,
                         ),
-                      ),
-                      const SizedBox(height: 2),
-                      // Active dot
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 200),
-                        width: isActive ? 4 : 0,
-                        height: isActive ? 4 : 0,
-                        decoration: const BoxDecoration(
-                          color: AppTheme.primary,
-                          shape: BoxShape.circle,
+                        const SizedBox(height: 2),
+                        Text(
+                          item.label,
+                          style: GoogleFonts.manrope(
+                            fontSize: 10,
+                            fontWeight:
+                                isActive ? FontWeight.w600 : FontWeight.w400,
+                            color: isActive
+                                ? palette.primary
+                                : palette.onSurfaceVariant,
+                          ),
                         ),
-                      ),
-                    ],
+                        const SizedBox(height: 2),
+                        // Active dot
+                        AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          width: isActive ? 4 : 0,
+                          height: isActive ? 4 : 0,
+                          decoration: BoxDecoration(
+                            color: palette.primary,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               );

--- a/lib/providers/history_provider.dart
+++ b/lib/providers/history_provider.dart
@@ -4,37 +4,71 @@ import '../utils/database_helper.dart';
 class HistoryProvider extends ChangeNotifier {
   List<CalculationHistory> _history = [];
   bool _isLoading = false;
+  String? _error;
 
   List<CalculationHistory> get history => _history;
   bool get isLoading => _isLoading;
+  String? get error => _error;
 
   Future<void> loadHistory() async {
     _isLoading = true;
+    _error = null;
     notifyListeners();
 
-    _history = await DatabaseHelper.instance.getHistory();
-
-    _isLoading = false;
-    notifyListeners();
+    try {
+      _history = await DatabaseHelper.instance.getHistory();
+    } catch (e) {
+      // Without this the spinner span forever — every failure looked like a
+      // slow load. Surface it instead.
+      _error = _describe(e);
+      _history = [];
+      debugPrint('HistoryProvider.loadHistory failed: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   Future<void> addHistory(CalculationHistory item) async {
-    await DatabaseHelper.instance.insertHistory(item);
+    try {
+      await DatabaseHelper.instance.insertHistory(item);
+    } catch (e) {
+      _error = _describe(e);
+      debugPrint('HistoryProvider.addHistory failed: $e');
+      notifyListeners();
+      return;
+    }
     await loadHistory();
   }
 
   Future<void> deleteHistory(int id) async {
-    await DatabaseHelper.instance.deleteHistory(id);
-    await loadHistory();
+    await _mutate(() => DatabaseHelper.instance.deleteHistory(id));
   }
 
   Future<void> togglePin(int id, bool isPinned) async {
-    await DatabaseHelper.instance.updateHistoryPin(id, isPinned);
-    await loadHistory();
+    await _mutate(() => DatabaseHelper.instance.updateHistoryPin(id, isPinned));
   }
 
   Future<void> clearHistory() async {
-    await DatabaseHelper.instance.clearHistory();
+    await _mutate(() => DatabaseHelper.instance.clearHistory());
+  }
+
+  Future<void> _mutate(Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (e) {
+      _error = _describe(e);
+      debugPrint('HistoryProvider mutation failed: $e');
+      notifyListeners();
+      return;
+    }
     await loadHistory();
+  }
+
+  String _describe(Object e) {
+    if (kIsWeb) {
+      return 'History storage is not available on the web build yet.';
+    }
+    return 'Could not open calculation history.\n$e';
   }
 }

--- a/lib/providers/shell_provider.dart
+++ b/lib/providers/shell_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+/// A calculation handed back to the calculator from History.
+typedef RestoredCalculation = ({String value, String? expression});
+
+/// Owns which tab is showing, plus the one-shot hand-off used when History
+/// sends a previous result back to the calculator.
+class ShellProvider extends ChangeNotifier {
+  static const int calculatorTab = 0;
+  static const int smartCalcTab = 1;
+  static const int historyTab = 2;
+
+  int _index = calculatorTab;
+  RestoredCalculation? _pending;
+
+  int get index => _index;
+
+  void setIndex(int value) {
+    if (value == _index) return;
+    _index = value;
+    notifyListeners();
+  }
+
+  /// Sends a stored calculation to the calculator and switches to that tab.
+  /// [expression] is the chain that produced [value], so the calculator can
+  /// show the working rather than just the answer.
+  void restoreToCalculator(String value, {String? expression}) {
+    _pending = (value: value, expression: expression);
+    _index = calculatorTab;
+    notifyListeners();
+  }
+
+  /// Reads and clears the pending calculation, so it is applied exactly once.
+  RestoredCalculation? takePending() {
+    final pending = _pending;
+    _pending = null;
+    return pending;
+  }
+}

--- a/lib/screens/calculator_screen.dart
+++ b/lib/screens/calculator_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../app/theme.dart';
 import '../providers/history_provider.dart';
+import '../providers/shell_provider.dart';
 import '../utils/calculator_logic.dart';
 import '../utils/database_helper.dart';
 import '../widgets/calculator_button.dart';
@@ -19,29 +19,52 @@ class CalculatorScreen extends StatefulWidget {
 class _CalculatorScreenState extends State<CalculatorScreen> {
   final CalculatorLogic _calculator = CalculatorLogic();
   bool _showFullDecimal = false;
+  ShellProvider? _shell;
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final shell = context.read<ShellProvider>();
+    if (identical(shell, _shell)) return;
+    _shell?.removeListener(_onShellChanged);
+    _shell = shell..addListener(_onShellChanged);
+  }
+
+  @override
+  void dispose() {
+    _shell?.removeListener(_onShellChanged);
+    super.dispose();
+  }
+
+  /// History can hand a previous calculation back to the calculator.
+  void _onShellChanged() {
+    final pending = _shell?.takePending();
+    if (pending == null || !mounted) return;
+    setState(() {
+      _showFullDecimal = false;
+      _calculator.restore(pending.value, expression: pending.expression);
+    });
+  }
+
+  /// Records the calculation that just completed. Called *after* [
+  /// CalculatorLogic.calculate], so the result actually exists — previously
+  /// this ran first and every entry was saved with an empty result.
   void _saveCalculation() {
-    final prev = _calculator.previousValue;
-    final op = _calculator.currentOperator;
-    final current = _calculator.displayValue;
-    if (prev.isEmpty || op.isEmpty) return;
+    final done = _calculator.lastCalculation;
+    if (done == null) return; // nothing evaluated, or it errored
 
     final now = DateTime.now();
     final history = CalculationHistory(
       type: 'basic_calculator',
-      name: 'Basic Calc ${DateFormat('MMM dd, HH:mm').format(now)}',
+      name: 'Basic Calculator',
       label: 'arithmetic',
       isPinned: false,
       timestamp: now,
-      inputs: {
-        'previousValue': prev,
-        'operator': op,
-        'currentValue': current,
-      },
-      results: {},
+      inputs: {'expression': done.expression},
+      results: {'result': done.result},
     );
 
-    Provider.of<HistoryProvider>(context, listen: false).addHistory(history);
+    context.read<HistoryProvider>().addHistory(history);
   }
 
   void _onButtonPressed(String value) {
@@ -64,7 +87,6 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
           _calculator.inputOperator(value);
           break;
         case '=':
-          _saveCalculation();
           _calculator.calculate();
           break;
         case '.':
@@ -73,120 +95,117 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
         case '±':
           _calculator.toggleSign();
           break;
-        case '%':
-          _calculator.percentage();
-          break;
         default:
           if (value.isNotEmpty && '0123456789'.contains(value)) {
             _calculator.inputNumber(value);
           }
       }
     });
+
+    // Persisting touches a provider, so keep it outside setState.
+    if (value == '=') _saveCalculation();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        // ── Display zone (#0e0e0e) ──────────────────────────────────────────
-        Expanded(
-          flex: 38,
-          child: Container(
-            color: AppTheme.background,
-            padding: const EdgeInsets.fromLTRB(24, 8, 24, 20),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                // Expression line
-                if (_calculator.expression.isNotEmpty)
-                  Text(
-                    _calculator.expression,
-                    style: GoogleFonts.manrope(
-                      fontSize: 18,
-                      color: AppTheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w400,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.right,
-                  ),
-                const SizedBox(height: 4),
-                // Main result
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    if (_calculator.isResultTruncated)
-                      GestureDetector(
-                        onTap: () => setState(
-                            () => _showFullDecimal = !_showFullDecimal),
-                        child: Padding(
-                          padding: const EdgeInsets.only(right: 8),
-                          child: Icon(
-                            _showFullDecimal
-                                ? Icons.unfold_less
-                                : Icons.unfold_more,
-                            size: 22,
-                            color: AppTheme.primary,
-                          ),
-                        ),
-                      ),
-                    Expanded(
-                      child: FittedBox(
-                        fit: BoxFit.scaleDown,
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          _showFullDecimal
-                              ? _calculator.fullResult
-                              : _calculator.displayValue,
-                          style: GoogleFonts.spaceGrotesk(
-                            fontSize: 72,
-                            fontWeight: FontWeight.w300,
-                            color: AppTheme.onSurface,
-                            letterSpacing: -1.5,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
+    final palette = context.palette;
 
-        // ── Keypad zone (#131313) ───────────────────────────────────────────
-        Expanded(
-          flex: 62,
-          child: Container(
-            color: AppTheme.surfaceContainerLow,
-            padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
-            child: Column(
-              children: [
-                _row(['C', 'CE', '⌫', '÷'],
-                    [ButtonType.clear, ButtonType.function, ButtonType.function, ButtonType.operator]),
-                const SizedBox(height: 10),
-                _row(['7', '8', '9', '×'],
-                    [ButtonType.number, ButtonType.number, ButtonType.number, ButtonType.operator]),
-                const SizedBox(height: 10),
-                _row(['4', '5', '6', '−'],
-                    [ButtonType.number, ButtonType.number, ButtonType.number, ButtonType.operator]),
-                const SizedBox(height: 10),
-                _row(['1', '2', '3', '+'],
-                    [ButtonType.number, ButtonType.number, ButtonType.number, ButtonType.operator]),
-                const SizedBox(height: 10),
-                _row(['±', '0', '.', '='],
-                    [ButtonType.function, ButtonType.number, ButtonType.number, ButtonType.equal]),
-              ],
+    return SafeArea(
+      top: false,
+      child: Column(
+        children: [
+          // ── Display zone ────────────────────────────────────────────────
+          Expanded(
+            flex: 38,
+            child: Container(
+              width: double.infinity,
+              color: palette.background,
+              padding: const EdgeInsets.fromLTRB(24, 8, 24, 20),
+              child: _Display(
+                calculator: _calculator,
+                showFullDecimal: _showFullDecimal,
+                onToggleFullDecimal: () =>
+                    setState(() => _showFullDecimal = !_showFullDecimal),
+              ),
             ),
           ),
-        ),
-      ],
+
+          // ── Keypad zone ─────────────────────────────────────────────────
+          Expanded(
+            flex: 62,
+            child: Container(
+              color: palette.surfaceContainerLow,
+              padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+              child: Column(
+                children: [
+                  _row(
+                    const ['C', 'CE', '⌫', '÷'],
+                    const [
+                      ButtonType.clear,
+                      ButtonType.function,
+                      ButtonType.function,
+                      ButtonType.operator,
+                    ],
+                    const ['Clear all', 'Clear entry', 'Backspace', 'Divide'],
+                  ),
+                  const SizedBox(height: 10),
+                  _row(
+                    const ['7', '8', '9', '×'],
+                    const [
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.operator,
+                    ],
+                    const ['7', '8', '9', 'Multiply'],
+                  ),
+                  const SizedBox(height: 10),
+                  _row(
+                    const ['4', '5', '6', '−'],
+                    const [
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.operator,
+                    ],
+                    const ['4', '5', '6', 'Subtract'],
+                  ),
+                  const SizedBox(height: 10),
+                  _row(
+                    const ['1', '2', '3', '+'],
+                    const [
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.operator,
+                    ],
+                    const ['1', '2', '3', 'Add'],
+                  ),
+                  const SizedBox(height: 10),
+                  _row(
+                    const ['±', '0', '.', '='],
+                    const [
+                      ButtonType.function,
+                      ButtonType.number,
+                      ButtonType.number,
+                      ButtonType.equal,
+                    ],
+                    const ['Toggle sign', '0', 'Decimal point', 'Equals'],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _row(List<String> labels, List<ButtonType> types) {
+  Widget _row(
+    List<String> labels,
+    List<ButtonType> types,
+    List<String> semantics,
+  ) {
     return Expanded(
       child: Row(
         children: List.generate(labels.length, (i) {
@@ -196,11 +215,171 @@ class _CalculatorScreenState extends State<CalculatorScreen> {
               child: CalculatorButton(
                 text: labels[i],
                 type: types[i],
+                semanticLabel: semantics[i],
                 onPressed: () => _onButtonPressed(labels[i]),
               ),
             ),
           );
         }),
+      ),
+    );
+  }
+}
+
+/// The expression + result readout.
+///
+/// Both lines are [Flexible] so that in landscape — where the display zone is
+/// only ~90dp tall — the text scales down instead of overflowing.
+class _Display extends StatelessWidget {
+  final CalculatorLogic calculator;
+  final bool showFullDecimal;
+  final VoidCallback onToggleFullDecimal;
+
+  const _Display({
+    required this.calculator,
+    required this.showFullDecimal,
+    required this.onToggleFullDecimal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final expression = calculator.expression;
+    final resultColor =
+        calculator.hasError ? palette.error : palette.onSurface;
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        // Running tape of every step since the last C. Chained arithmetic
+        // collapses to a single running total, so this is the only place the
+        // earlier steps of a long calculation stay visible.
+        if (calculator.tape.isNotEmpty)
+          Expanded(
+            flex: 3,
+            child: _Tape(text: calculator.tape),
+          ),
+        if (expression.isNotEmpty)
+          Flexible(
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.centerRight,
+              child: Text(
+                expression,
+                style: GoogleFonts.manrope(
+                  fontSize: 18,
+                  color: palette.onSurfaceVariant,
+                  fontWeight: FontWeight.w400,
+                ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+        const SizedBox(height: 4),
+        Flexible(
+          flex: 4,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (calculator.isResultTruncated)
+                _PrecisionToggle(
+                  expanded: showFullDecimal,
+                  onTap: onToggleFullDecimal,
+                ),
+              Expanded(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    showFullDecimal
+                        ? calculator.fullResult
+                        : calculator.displayValue,
+                    style: GoogleFonts.spaceGrotesk(
+                      fontSize: 72,
+                      fontWeight: FontWeight.w300,
+                      color: resultColor,
+                      letterSpacing: -1.5,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The running tape of completed steps.
+///
+/// `reverse: true` anchors the content to the bottom, so a short tape sits
+/// just above the expression line and a long one keeps the newest step in
+/// view while still letting the user scroll back through the whole chain.
+class _Tape extends StatelessWidget {
+  final String text;
+
+  const _Tape({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Semantics(
+      label: 'Calculation tape',
+      value: text,
+      child: SingleChildScrollView(
+        reverse: true,
+        child: Text(
+          text,
+          textAlign: TextAlign.right,
+          style: GoogleFonts.spaceGrotesk(
+            fontSize: 15,
+            height: 1.5,
+            fontWeight: FontWeight.w400,
+            color: palette.onSurfaceVariant.withValues(alpha: 0.7),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Expands a rounded result to full precision. Sits next to the number with a
+/// 48dp tap target and a tinted chip, rather than a bare 22px glyph stranded
+/// at the far edge of the screen.
+class _PrecisionToggle extends StatelessWidget {
+  final bool expanded;
+  final VoidCallback onTap;
+
+  const _PrecisionToggle({required this.expanded, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Semantics(
+      button: true,
+      label: expanded ? 'Show rounded result' : 'Show full precision',
+      child: Padding(
+        padding: const EdgeInsets.only(right: 8),
+        child: Material(
+          color: palette.primary.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(14),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(14),
+            child: SizedBox(
+              width: 48,
+              height: 48,
+              child: Icon(
+                expanded ? Icons.unfold_less : Icons.unfold_more,
+                size: 22,
+                color: palette.primary,
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/compound_interest_screen.dart
+++ b/lib/screens/compound_interest_screen.dart
@@ -24,6 +24,9 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
   final _rateController = TextEditingController();
   final _yearsController = TextEditingController();
 
+  final _scrollController = ScrollController();
+  final _resultKey = GlobalKey();
+
   int _compoundingFrequency = 12;
   _CompoundResult? _result;
 
@@ -42,10 +45,12 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
     _principalController.dispose();
     _rateController.dispose();
     _yearsController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
   void _calculate() {
+    FocusScope.of(context).unfocus();
     if (!_formKey.currentState!.validate()) return;
 
     final p = double.parse(_principalController.text.replaceAll(',', ''));
@@ -82,8 +87,24 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
       );
     });
 
-    _saveToHistory(p, r * 100, _compoundingFrequency, t, finalAmount,
-        interestEarned);
+    _saveToHistory(
+        p, r * 100, _compoundingFrequency, t, finalAmount, interestEarned);
+    _revealResult();
+  }
+
+  /// The answer renders below the fold, so tapping Calculate used to look like
+  /// nothing happened. Bring it into view once the card has been laid out.
+  void _revealResult() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _resultKey.currentContext;
+      if (ctx == null || !mounted) return;
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeOutCubic,
+        alignment: 0.05,
+      );
+    });
   }
 
   void _saveToHistory(double principal, double rate, int freq, double years,
@@ -91,7 +112,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
     final now = DateTime.now();
     final history = CalculationHistory(
       type: 'compound_interest',
-      name: 'Compound Interest ${DateFormat('MMM dd, HH:mm').format(now)}',
+      name: 'Compound Interest',
       label: 'finance',
       isPinned: false,
       timestamp: now,
@@ -106,18 +127,20 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
         'interestEarned': _currencyFormat.format(interestEarned),
       },
     );
-    Provider.of<HistoryProvider>(context, listen: false).addHistory(history);
+    context.read<HistoryProvider>().addHistory(history);
   }
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+
     return Scaffold(
-      backgroundColor: AppTheme.background,
+      backgroundColor: palette.background,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios_new_rounded,
-              color: AppTheme.onSurface, size: 20),
+          icon: Icon(Icons.arrow_back_ios_new_rounded,
+              color: palette.onSurface, size: 20),
           onPressed: () => Navigator.pop(context),
         ),
         centerTitle: true,
@@ -126,11 +149,12 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
           style: GoogleFonts.spaceGrotesk(
             fontSize: 18,
             fontWeight: FontWeight.w600,
-            color: AppTheme.onSurface,
+            color: palette.onSurface,
           ),
         ),
       ),
       body: SingleChildScrollView(
+        controller: _scrollController,
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
         child: Form(
           key: _formKey,
@@ -162,7 +186,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
                       style: GoogleFonts.spaceGrotesk(
                         fontSize: 20,
                         fontWeight: FontWeight.w600,
-                        color: AppTheme.onSurface,
+                        color: palette.onSurface,
                       ),
                     ),
                     const SizedBox(height: 4),
@@ -170,7 +194,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
                       'A = P(1 + r/n)ⁿᵗ',
                       style: GoogleFonts.spaceGrotesk(
                         fontSize: 13,
-                        color: AppTheme.onSurfaceVariant,
+                        color: palette.onSurfaceVariant,
                         letterSpacing: 0.5,
                       ),
                     ),
@@ -183,7 +207,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
               Container(
                 padding: const EdgeInsets.all(20),
                 decoration: BoxDecoration(
-                  color: AppTheme.surfaceContainerLow,
+                  color: palette.surfaceContainerLow,
                   borderRadius: BorderRadius.circular(24),
                 ),
                 child: Column(
@@ -193,6 +217,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
                       label: 'Principal Amount',
                       hint: '10,000',
                       prefix: '₹',
+                      textInputAction: TextInputAction.next,
                     ),
                     const SizedBox(height: 16),
                     _buildField(
@@ -201,6 +226,7 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
                       hint: '8.0',
                       suffix: '%',
                       allowDecimal: true,
+                      textInputAction: TextInputAction.next,
                     ),
                     const SizedBox(height: 16),
                     _FrequencySelector(
@@ -216,6 +242,8 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
                       hint: '5',
                       suffix: 'yrs',
                       allowDecimal: true,
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _calculate(),
                     ),
                   ],
                 ),
@@ -223,32 +251,36 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
               const SizedBox(height: 16),
 
               // ── Calculate button ──────────────────────────────────────────
-              GestureDetector(
-                onTap: _calculate,
-                child: Container(
-                  height: 56,
-                  decoration: BoxDecoration(
-                    gradient: const LinearGradient(
-                      colors: [Color(0xFF00C853), Color(0xFF069E46)],
-                      begin: Alignment.centerLeft,
-                      end: Alignment.centerRight,
-                    ),
-                    borderRadius: BorderRadius.circular(999),
-                    boxShadow: [
-                      BoxShadow(
-                        color: const Color(0xFF00C853).withValues(alpha: 0.3),
-                        blurRadius: 16,
-                        offset: const Offset(0, 4),
+              Semantics(
+                button: true,
+                label: 'Calculate compound interest',
+                child: GestureDetector(
+                  onTap: _calculate,
+                  child: Container(
+                    height: 56,
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF00C853), Color(0xFF069E46)],
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
                       ),
-                    ],
-                  ),
-                  child: Center(
-                    child: Text(
-                      'Calculate  →',
-                      style: GoogleFonts.spaceGrotesk(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        color: Colors.white,
+                      borderRadius: BorderRadius.circular(999),
+                      boxShadow: [
+                        BoxShadow(
+                          color: const Color(0xFF00C853).withValues(alpha: 0.3),
+                          blurRadius: 16,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Calculate  →',
+                        style: GoogleFonts.spaceGrotesk(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
                       ),
                     ),
                   ),
@@ -259,11 +291,15 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
               if (_result != null) ...[
                 const SizedBox(height: 20),
                 _ResultCard(
-                    result: _result!, currencyFormat: _currencyFormat),
+                  key: _resultKey,
+                  result: _result!,
+                  currencyFormat: _currencyFormat,
+                ),
                 const SizedBox(height: 12),
                 _BreakdownCard(
-                    breakdown: _result!.breakdown,
-                    currencyFormat: _currencyFormat),
+                  breakdown: _result!.breakdown,
+                  currencyFormat: _currencyFormat,
+                ),
               ],
             ],
           ),
@@ -279,26 +315,29 @@ class _CompoundInterestScreenState extends State<CompoundInterestScreen> {
     String? prefix,
     String? suffix,
     bool allowDecimal = false,
+    TextInputAction textInputAction = TextInputAction.next,
+    ValueChanged<String>? onSubmitted,
   }) {
+    final palette = context.palette;
     return TextFormField(
       controller: controller,
-      keyboardType:
-          TextInputType.numberWithOptions(decimal: allowDecimal),
+      keyboardType: TextInputType.numberWithOptions(decimal: allowDecimal),
+      textInputAction: textInputAction,
+      onFieldSubmitted: onSubmitted,
       inputFormatters: [
         FilteringTextInputFormatter.allow(
             RegExp(allowDecimal ? r'[\d.]' : r'\d')),
       ],
-      style: GoogleFonts.spaceGrotesk(
-          color: AppTheme.onSurface, fontSize: 15),
+      style: GoogleFonts.spaceGrotesk(color: palette.onSurface, fontSize: 15),
       decoration: InputDecoration(
         labelText: label,
         hintText: hint,
         prefixText: prefix != null ? '$prefix  ' : null,
         suffixText: suffix,
-        prefixStyle: GoogleFonts.manrope(
-            color: AppTheme.onSurfaceVariant, fontSize: 15),
-        suffixStyle: GoogleFonts.manrope(
-            color: AppTheme.onSurfaceVariant, fontSize: 13),
+        prefixStyle:
+            GoogleFonts.manrope(color: palette.onSurfaceVariant, fontSize: 15),
+        suffixStyle:
+            GoogleFonts.manrope(color: palette.onSurfaceVariant, fontSize: 13),
       ),
       validator: (v) {
         if (v == null || v.isEmpty) return 'Required';
@@ -324,51 +363,58 @@ class _FrequencySelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           'Compounding',
-          style: GoogleFonts.manrope(
-              fontSize: 12, color: AppTheme.onSurfaceVariant),
+          style:
+              GoogleFonts.manrope(fontSize: 12, color: palette.onSurfaceVariant),
         ),
         const SizedBox(height: 8),
         Container(
           padding: const EdgeInsets.all(4),
           decoration: BoxDecoration(
-            color: AppTheme.surfaceContainerHigh,
+            color: palette.surfaceContainerHigh,
             borderRadius: BorderRadius.circular(999),
           ),
           child: Row(
             children: frequencies.map((f) {
               final isActive = f.value == selected;
               return Expanded(
-                child: GestureDetector(
-                  onTap: () => onChanged(f.value),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    decoration: BoxDecoration(
-                      gradient: isActive
-                          ? const LinearGradient(
-                              colors: [AppTheme.primary, AppTheme.primaryDim],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            )
-                          : null,
-                      borderRadius: BorderRadius.circular(999),
-                    ),
-                    child: Center(
-                      child: Text(
-                        f.label,
-                        style: GoogleFonts.manrope(
-                          fontSize: 11,
-                          fontWeight: isActive
-                              ? FontWeight.w700
-                              : FontWeight.w400,
-                          color: isActive
-                              ? Colors.white
-                              : AppTheme.onSurfaceVariant,
+                child: Semantics(
+                  button: true,
+                  selected: isActive,
+                  child: GestureDetector(
+                    onTap: () => onChanged(f.value),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      decoration: BoxDecoration(
+                        gradient: isActive
+                            ? LinearGradient(
+                                colors: [palette.primary, palette.primaryDim],
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                              )
+                            : null,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Center(
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Text(
+                            f.label,
+                            style: GoogleFonts.manrope(
+                              fontSize: 11,
+                              fontWeight:
+                                  isActive ? FontWeight.w700 : FontWeight.w400,
+                              color: isActive
+                                  ? Colors.white
+                                  : palette.onSurfaceVariant,
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -418,20 +464,28 @@ class _ResultCard extends StatelessWidget {
   final _CompoundResult result;
   final NumberFormat currencyFormat;
 
-  const _ResultCard({required this.result, required this.currencyFormat});
+  const _ResultCard({
+    super.key,
+    required this.result,
+    required this.currencyFormat,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     final interestPercent =
         (result.interestEarned / result.principal * 100).toStringAsFixed(1);
 
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF13121F),
+        color: isDark
+            ? const Color(0xFF13121F)
+            : palette.primary.withValues(alpha: 0.06),
         borderRadius: BorderRadius.circular(24),
         border: Border.all(
-          color: AppTheme.primary.withValues(alpha: 0.12),
+          color: palette.primary.withValues(alpha: 0.12),
           width: 1,
         ),
       ),
@@ -441,39 +495,50 @@ class _ResultCard extends StatelessWidget {
           Text(
             'Final Amount',
             style: GoogleFonts.manrope(
-                fontSize: 12, color: AppTheme.onSurfaceVariant),
+                fontSize: 12, color: palette.onSurfaceVariant),
           ),
           const SizedBox(height: 4),
-          Text(
-            '₹ ${currencyFormat.format(result.finalAmount)}',
-            style: GoogleFonts.spaceGrotesk(
-              fontSize: 32,
-              fontWeight: FontWeight.w700,
-              color: AppTheme.primary,
-              letterSpacing: -0.5,
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              '₹ ${currencyFormat.format(result.finalAmount)}',
+              style: GoogleFonts.spaceGrotesk(
+                fontSize: 32,
+                fontWeight: FontWeight.w700,
+                color: palette.primary,
+                letterSpacing: -0.5,
+              ),
             ),
           ),
           const SizedBox(height: 16),
-          Row(
-            children: [
-              _Chip(
+          // Equal-height chips without forcing an infinite height inside the
+          // scroll view (CrossAxisAlignment.stretch does exactly that).
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _Chip(
                   label: 'Principal',
                   value: '₹ ${currencyFormat.format(result.principal)}',
-                  color: AppTheme.onSurfaceVariant),
-              const SizedBox(width: 8),
-              _Chip(
+                  color: palette.onSurfaceVariant,
+                ),
+                const SizedBox(width: 8),
+                _Chip(
                   label: 'Interest',
                   value:
                       '₹ ${currencyFormat.format(result.interestEarned)} (+$interestPercent%)',
-                  color: AppTheme.green),
-            ],
+                  color: palette.green,
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 12),
           Center(
             child: Text(
               'Effective Annual Rate: ${result.effectiveAnnualRate.toStringAsFixed(2)}%',
               style: GoogleFonts.manrope(
-                  fontSize: 12, color: AppTheme.onSurfaceVariant),
+                  fontSize: 12, color: palette.onSurfaceVariant),
             ),
           ),
         ],
@@ -487,30 +552,35 @@ class _Chip extends StatelessWidget {
   final String value;
   final Color color;
 
-  const _Chip(
-      {required this.label, required this.value, required this.color});
+  const _Chip({required this.label, required this.value, required this.color});
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     return Expanded(
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         decoration: BoxDecoration(
-          color: AppTheme.surfaceContainerHigh,
+          color: palette.surfaceContainerHigh,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Text(label,
                 style: GoogleFonts.manrope(
-                    fontSize: 10, color: AppTheme.onSurfaceVariant)),
+                    fontSize: 10, color: palette.onSurfaceVariant)),
             const SizedBox(height: 2),
-            Text(value,
-                style: GoogleFonts.spaceGrotesk(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: color)),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.centerLeft,
+              child: Text(value,
+                  style: GoogleFonts.spaceGrotesk(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: color)),
+            ),
           ],
         ),
       ),
@@ -528,10 +598,11 @@ class _BreakdownCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: AppTheme.surfaceContainer,
+        color: palette.surfaceContainer,
         borderRadius: BorderRadius.circular(24),
       ),
       child: Column(
@@ -542,16 +613,16 @@ class _BreakdownCard extends StatelessWidget {
             style: GoogleFonts.spaceGrotesk(
               fontSize: 14,
               fontWeight: FontWeight.w600,
-              color: AppTheme.onSurface,
+              color: palette.onSurface,
             ),
           ),
           const SizedBox(height: 16),
           // Header
           Row(
             children: [
-              _cell('Year', flex: 1, isHeader: true),
-              _cell('Balance', flex: 2, isHeader: true),
-              _cell('Interest', flex: 2, isHeader: true),
+              _cell(context, 'Year', flex: 1, isHeader: true),
+              _cell(context, 'Balance', flex: 2, isHeader: true),
+              _cell(context, 'Interest', flex: 2, isHeader: true),
             ],
           ),
           const SizedBox(height: 8),
@@ -559,15 +630,14 @@ class _BreakdownCard extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 6),
                 child: Row(
                   children: [
-                    _cell(
+                    _cell(context,
                         row.isPartial ? '${row.year}*' : '${row.year}',
                         flex: 1),
-                    _cell('₹ ${currencyFormat.format(row.balance)}',
+                    _cell(context, '₹ ${currencyFormat.format(row.balance)}',
                         flex: 2),
-                    _cell(
+                    _cell(context,
                         '₹ ${currencyFormat.format(row.interestThisYear)}',
-                        flex: 2,
-                        color: AppTheme.green),
+                        flex: 2, color: palette.green),
                   ],
                 ),
               )),
@@ -577,7 +647,7 @@ class _BreakdownCard extends StatelessWidget {
               child: Text(
                 '* Partial year',
                 style: GoogleFonts.manrope(
-                    fontSize: 11, color: AppTheme.onSurfaceVariant),
+                    fontSize: 11, color: palette.onSurfaceVariant),
               ),
             ),
         ],
@@ -585,18 +655,22 @@ class _BreakdownCard extends StatelessWidget {
     );
   }
 
-  Widget _cell(String text,
+  Widget _cell(BuildContext context, String text,
       {required int flex, bool isHeader = false, Color? color}) {
+    final palette = context.palette;
     return Expanded(
       flex: flex,
-      child: Text(
-        text,
-        style: GoogleFonts.spaceGrotesk(
-          fontSize: isHeader ? 12 : 13,
-          fontWeight:
-              isHeader ? FontWeight.w700 : FontWeight.w400,
-          color: color ??
-              (isHeader ? AppTheme.onSurfaceVariant : AppTheme.onSurface),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.centerLeft,
+        child: Text(
+          text,
+          style: GoogleFonts.spaceGrotesk(
+            fontSize: isHeader ? 12 : 13,
+            fontWeight: isHeader ? FontWeight.w700 : FontWeight.w400,
+            color: color ??
+                (isHeader ? palette.onSurfaceVariant : palette.onSurface),
+          ),
         ),
       ),
     );

--- a/lib/screens/emi_calculator_screen.dart
+++ b/lib/screens/emi_calculator_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app/theme.dart';
+import '../providers/history_provider.dart';
+import '../utils/database_helper.dart';
+import '../utils/finance.dart';
+import '../utils/money.dart';
+import '../widgets/finance_widgets.dart';
+
+/// "What will this loan cost me every month?"
+class EmiCalculatorScreen extends StatefulWidget {
+  const EmiCalculatorScreen({super.key});
+
+  static const List<Color> accent = [Color(0xFFFF9800), Color(0xFFE65100)];
+
+  @override
+  State<EmiCalculatorScreen> createState() => _EmiCalculatorScreenState();
+}
+
+class _EmiCalculatorScreenState extends State<EmiCalculatorScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountController = TextEditingController();
+  final _rateController = TextEditingController();
+  final _tenureController = TextEditingController();
+  final _resultKey = GlobalKey();
+
+  _TenureUnit _unit = _TenureUnit.years;
+  EmiResult? _result;
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _rateController.dispose();
+    _tenureController.dispose();
+    super.dispose();
+  }
+
+  int get _months {
+    final raw = double.parse(_tenureController.text.replaceAll(',', ''));
+    return _unit == _TenureUnit.years ? (raw * 12).round() : raw.round();
+  }
+
+  void _calculate() {
+    FocusScope.of(context).unfocus();
+    if (!_formKey.currentState!.validate()) return;
+
+    final result = calculateEmi(
+      principal: double.parse(_amountController.text.replaceAll(',', '')),
+      annualRatePercent: double.parse(_rateController.text),
+      months: _months,
+    );
+
+    setState(() => _result = result);
+    _saveToHistory(result);
+    _revealResult();
+  }
+
+  void _revealResult() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _resultKey.currentContext;
+      if (ctx == null || !mounted) return;
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeOutCubic,
+        alignment: 0.05,
+      );
+    });
+  }
+
+  void _saveToHistory(EmiResult result) {
+    final now = DateTime.now();
+    context.read<HistoryProvider>().addHistory(
+          CalculationHistory(
+            type: 'emi',
+            name: 'EMI Calculator',
+            label: 'finance',
+            isPinned: false,
+            timestamp: now,
+            inputs: {
+              'principal': money(result.principal),
+              'rate': '${_rateController.text}%',
+              'months': result.months,
+            },
+            results: {
+              'emi': money(result.emi),
+              'totalInterest': money(result.totalInterest),
+              'totalPayment': money(result.totalPayment),
+            },
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final result = _result;
+
+    return FinanceScaffold(
+      title: 'EMI Calculator',
+      heroSubtitle: 'EMI = P·i·(1+i)ⁿ / ((1+i)ⁿ − 1)',
+      icon: Icons.payments_outlined,
+      accent: EmiCalculatorScreen.accent,
+      formKey: _formKey,
+      onCalculate: _calculate,
+      fields: [
+        MoneyField(
+          controller: _amountController,
+          label: 'Loan Amount',
+          hint: '10,00,000',
+          prefix: '₹',
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          controller: _rateController,
+          label: 'Interest Rate',
+          hint: '9.0',
+          suffix: '% p.a.',
+          allowDecimal: true,
+        ),
+        const SizedBox(height: 16),
+        SegmentedSelector<_TenureUnit>(
+          label: 'Tenure in',
+          options: const [
+            (label: 'Years', value: _TenureUnit.years),
+            (label: 'Months', value: _TenureUnit.months),
+          ],
+          selected: _unit,
+          onChanged: (value) => setState(() => _unit = value),
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          controller: _tenureController,
+          label: 'Tenure',
+          hint: _unit == _TenureUnit.years ? '5' : '60',
+          suffix: _unit == _TenureUnit.years ? 'yrs' : 'mo',
+          allowDecimal: _unit == _TenureUnit.years,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => _calculate(),
+          extraValidator: (value) {
+            final months = _unit == _TenureUnit.years ? value * 12 : value;
+            if (months < 1) return 'At least one month';
+            if (months > 600) return 'Maximum 50 years';
+            return null;
+          },
+        ),
+      ],
+      resultKey: _resultKey,
+      results: result == null
+          ? const []
+          : [
+              HeadlineResult(
+                key: _resultKey,
+                label: 'Monthly EMI',
+                value: rupees(result.emi),
+                stats: [
+                  (
+                    label: 'Principal',
+                    value: rupees(result.principal),
+                    color: palette.onSurfaceVariant,
+                  ),
+                  (
+                    label: 'Total Interest',
+                    value: rupees(result.totalInterest),
+                    color: palette.error,
+                  ),
+                  (
+                    label: 'Total Payable',
+                    value: rupees(result.totalPayment),
+                    color: palette.onSurface,
+                  ),
+                  (
+                    label: 'Tenure',
+                    value: formatMonths(result.months),
+                    color: palette.onSurfaceVariant,
+                  ),
+                ],
+                footnote:
+                    'Interest is ${percent(result.interestShare, decimals: 1)} '
+                    'of everything you repay',
+              ),
+              const SizedBox(height: 12),
+              SplitBar(
+                leftLabel: 'Principal ${rupees(result.principal)}',
+                rightLabel: 'Interest ${rupees(result.totalInterest)}',
+                leftFraction: 1 - result.interestShare,
+                leftColor: palette.primary,
+                rightColor: palette.error,
+              ),
+            ],
+    );
+  }
+}
+
+enum _TenureUnit { years, months }

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -5,7 +5,11 @@ import 'package:provider/provider.dart';
 
 import '../app/theme.dart';
 import '../providers/history_provider.dart';
+import '../providers/shell_provider.dart';
 import '../utils/database_helper.dart';
+import '../utils/finance.dart' show formatMonths;
+import '../utils/money.dart' show years;
+import '../widgets/app_snackbar.dart';
 
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});
@@ -19,22 +23,31 @@ class _HistoryScreenState extends State<HistoryScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      Provider.of<HistoryProvider>(context, listen: false).loadHistory();
+      if (mounted) context.read<HistoryProvider>().loadHistory();
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+
     return Consumer<HistoryProvider>(
       builder: (context, provider, child) {
         if (provider.isLoading) {
-          return const Center(
-            child: CircularProgressIndicator(color: AppTheme.primary),
+          return Center(
+            child: CircularProgressIndicator(color: palette.primary),
+          );
+        }
+
+        if (provider.error != null) {
+          return _ErrorState(
+            message: provider.error!,
+            onRetry: provider.loadHistory,
           );
         }
 
         if (provider.history.isEmpty) {
-          return _EmptyState();
+          return const _EmptyState();
         }
 
         return Column(
@@ -46,10 +59,12 @@ class _HistoryScreenState extends State<HistoryScreen> {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(
-                    '${provider.history.length} calculations',
+                    provider.history.length == 1
+                        ? '1 calculation'
+                        : '${provider.history.length} calculations',
                     style: GoogleFonts.manrope(
                       fontSize: 12,
-                      color: AppTheme.onSurfaceVariant,
+                      color: palette.onSurfaceVariant,
                       letterSpacing: 0.3,
                     ),
                   ),
@@ -59,7 +74,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
                       'Clear All',
                       style: GoogleFonts.manrope(
                         fontSize: 12,
-                        color: AppTheme.error,
+                        color: palette.error,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
@@ -69,8 +84,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
             ),
             Expanded(
               child: ListView.separated(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
                 itemCount: provider.history.length,
                 separatorBuilder: (_, __) => const SizedBox(height: 10),
                 itemBuilder: (context, index) {
@@ -78,8 +92,8 @@ class _HistoryScreenState extends State<HistoryScreen> {
                   return _HistoryCard(
                     history: item,
                     onDelete: () => provider.deleteHistory(item.id!),
-                    onPin: () =>
-                        provider.togglePin(item.id!, !item.isPinned),
+                    onPin: () => provider.togglePin(item.id!, !item.isPinned),
+                    onTap: () => _restore(context, item),
                   );
                 },
               ),
@@ -90,39 +104,119 @@ class _HistoryScreenState extends State<HistoryScreen> {
     );
   }
 
+  /// Sends a stored calculation back to the calculator so it can be reused,
+  /// carrying the working with it rather than just the answer.
+  void _restore(BuildContext context, CalculationHistory item) {
+    final restorable = _restorable(item);
+    if (restorable == null) {
+      showAppSnackBar(context, 'Nothing to load from this entry');
+      return;
+    }
+    context.read<ShellProvider>().restoreToCalculator(
+          restorable.value,
+          expression: restorable.expression,
+        );
+    showAppSnackBar(context, 'Loaded ${restorable.value} into the calculator');
+  }
+
+  static RestoredCalculation? _restorable(CalculationHistory item) {
+    // The single number worth sending back to the calculator, per type.
+    final raw = item.results['result'] ??
+        item.results['finalAmount'] ??
+        item.results['emi'] ??
+        item.results['maturity'] ??
+        item.results['interestSaved'];
+    if (raw == null) return null;
+    // Stored money values carry grouping separators; the calculator wants a
+    // bare number it can parse.
+    final cleaned = raw.toString().replaceAll(',', '');
+    if (double.tryParse(cleaned) == null) return null;
+    return (value: cleaned, expression: _restorableExpression(item));
+  }
+
+  /// The working behind a stored result, shown on the calculator's tape.
+  static String? _restorableExpression(CalculationHistory item) {
+    switch (item.type) {
+      case 'basic_calculator':
+        final expression = item.inputs['expression'];
+        if (expression != null && '$expression'.isNotEmpty) {
+          return '$expression';
+        }
+        // Rows written before the schema change kept the operands apart.
+        final legacy = [
+          item.inputs['previousValue'],
+          item.inputs['operator'],
+          item.inputs['currentValue'],
+        ].where((e) => e != null && '$e'.isNotEmpty).join(' ');
+        return legacy.isEmpty ? null : legacy;
+      case 'compound_interest':
+        final principal = item.inputs['principal'];
+        final rate = item.inputs['rate'];
+        final term = item.inputs['years'];
+        if (principal == null || rate == null || term == null) return null;
+        return '₹$principal @ $rate for ${years(term)} yr';
+      case 'emi':
+        final principal = item.inputs['principal'];
+        final rate = item.inputs['rate'];
+        final months = item.inputs['months'];
+        if (principal == null || rate == null || months == null) return null;
+        return 'EMI on ₹$principal @ $rate over '
+            '${formatMonths(int.tryParse('$months') ?? 0)}';
+      case 'loan_payoff':
+        final principal = item.inputs['principal'];
+        final payoff = item.results['payoff'];
+        if (principal == null || payoff == null) return null;
+        return 'Interest saved on ₹$principal, cleared in $payoff';
+      case 'investment_sip':
+        final monthly = item.inputs['monthly'];
+        final rate = item.inputs['rate'];
+        final years = item.inputs['years'];
+        if (monthly == null || rate == null || years == null) return null;
+        return 'SIP ₹$monthly/mo @ $rate for $years yr';
+      default:
+        return null;
+    }
+  }
+
+
   void _showClearDialog(BuildContext context, HistoryProvider provider) {
+    final palette = context.palette;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: AppTheme.surfaceContainerHigh,
-        shape:
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        backgroundColor: palette.surfaceContainerHigh,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
         title: Text(
           'Clear History',
           style: GoogleFonts.spaceGrotesk(
-              color: AppTheme.onSurface, fontWeight: FontWeight.w600),
+            color: palette.onSurface,
+            fontWeight: FontWeight.w600,
+          ),
         ),
         content: Text(
           'This will permanently delete all calculation history.',
-          style:
-              GoogleFonts.manrope(color: AppTheme.onSurfaceVariant),
+          style: GoogleFonts.manrope(color: palette.onSurfaceVariant),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text('Cancel',
-                style: GoogleFonts.manrope(
-                    color: AppTheme.onSurfaceVariant)),
+            child: Text(
+              'Cancel',
+              style: GoogleFonts.manrope(color: palette.onSurfaceVariant),
+            ),
           ),
           TextButton(
             onPressed: () {
               provider.clearHistory();
               Navigator.pop(context);
             },
-            child: Text('Clear',
-                style: GoogleFonts.manrope(
-                    color: AppTheme.error,
-                    fontWeight: FontWeight.w600)),
+            child: Text(
+              'Clear',
+              style: GoogleFonts.manrope(
+                color: palette.error,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
         ],
       ),
@@ -131,8 +225,11 @@ class _HistoryScreenState extends State<HistoryScreen> {
 }
 
 class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -140,12 +237,12 @@ class _EmptyState extends StatelessWidget {
           Container(
             width: 72,
             height: 72,
-            decoration: const BoxDecoration(
-              color: AppTheme.surfaceContainerHigh,
+            decoration: BoxDecoration(
+              color: palette.surfaceContainerHigh,
               shape: BoxShape.circle,
             ),
-            child: const Icon(Icons.history_outlined,
-                size: 32, color: AppTheme.onSurfaceVariant),
+            child: Icon(Icons.history_outlined,
+                size: 32, color: palette.onSurfaceVariant),
           ),
           const SizedBox(height: 16),
           Text(
@@ -153,16 +250,75 @@ class _EmptyState extends StatelessWidget {
             style: GoogleFonts.spaceGrotesk(
               fontSize: 16,
               fontWeight: FontWeight.w600,
-              color: AppTheme.onSurface,
+              color: palette.onSurface,
             ),
           ),
           const SizedBox(height: 6),
           Text(
             'Start calculating to see your history here',
             style: GoogleFonts.manrope(
-                fontSize: 13, color: AppTheme.onSurfaceVariant),
+                fontSize: 13, color: palette.onSurfaceVariant),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorState({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                color: palette.errorContainer,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(Icons.error_outline_rounded,
+                  size: 32, color: palette.error),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'History unavailable',
+              style: GoogleFonts.spaceGrotesk(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: palette.onSurface,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.manrope(
+                  fontSize: 13, color: palette.onSurfaceVariant),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: onRetry,
+              child: Text(
+                'Try again',
+                style: GoogleFonts.manrope(
+                  color: palette.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -172,111 +328,136 @@ class _HistoryCard extends StatelessWidget {
   final CalculationHistory history;
   final VoidCallback onDelete;
   final VoidCallback onPin;
+  final VoidCallback onTap;
 
   const _HistoryCard({
     required this.history,
     required this.onDelete,
     required this.onPin,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     final resultText = _getResultText();
-    final resultColor = _getResultColor();
+    final resultColor = _getResultColor(palette);
+    final avatarColor = _getAvatarColor(palette);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-      decoration: BoxDecoration(
-        color: history.isPinned
-            ? AppTheme.surfaceContainerHigh
-            : AppTheme.surfaceContainer,
+    return Material(
+      color: history.isPinned
+          ? palette.primary.withValues(alpha: 0.08)
+          : palette.surfaceContainer,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap,
         borderRadius: BorderRadius.circular(16),
-      ),
-      child: Row(
-        children: [
-          // Avatar
-          Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: _getAvatarColor().withValues(alpha: 0.15),
-              shape: BoxShape.circle,
-            ),
-            child: Center(
-              child: Text(
-                _getAvatarLabel(),
-                style: GoogleFonts.spaceGrotesk(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: _getAvatarColor(),
-                ),
-              ),
-            ),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            // Pinned rows get a visible accent border — the old treatment
+            // shifted the background by two shades of near-black, which read
+            // as no change at all.
+            border: history.isPinned
+                ? Border.all(color: palette.primary.withValues(alpha: 0.55))
+                : null,
           ),
-          const SizedBox(width: 12),
-
-          // Content
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  history.name,
-                  style: GoogleFonts.manrope(
-                    fontSize: 11,
-                    color: AppTheme.onSurfaceVariant,
-                    letterSpacing: 0.2,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  DateFormat('MMM dd, yyyy · HH:mm')
-                      .format(history.timestamp),
-                  style: GoogleFonts.manrope(
-                    fontSize: 10,
-                    color: AppTheme.onSurfaceVariant.withValues(alpha: 0.6),
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  resultText,
-                  style: GoogleFonts.spaceGrotesk(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: resultColor,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-          ),
-
-          // Actions
-          Row(
-            mainAxisSize: MainAxisSize.min,
+          child: Row(
             children: [
-              GestureDetector(
-                onTap: onPin,
-                child: Icon(
-                  history.isPinned
-                      ? Icons.push_pin_rounded
-                      : Icons.push_pin_outlined,
-                  size: 18,
-                  color: history.isPinned
-                      ? const Color(0xFFFFD600)
-                      : AppTheme.onSurfaceVariant,
+              // Avatar
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: avatarColor.withValues(alpha: 0.15),
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    _getAvatarLabel(),
+                    style: GoogleFonts.spaceGrotesk(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: avatarColor,
+                    ),
+                  ),
                 ),
               ),
               const SizedBox(width: 12),
-              GestureDetector(
-                onTap: onDelete,
-                child: const Icon(Icons.delete_outline_rounded,
-                    size: 18, color: AppTheme.onSurfaceVariant),
+
+              // Content
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            history.name,
+                            style: GoogleFonts.manrope(
+                              fontSize: 11,
+                              color: palette.onSurfaceVariant,
+                              letterSpacing: 0.2,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Text(
+                          DateFormat('MMM dd · HH:mm').format(history.timestamp),
+                          style: GoogleFonts.manrope(
+                            fontSize: 10,
+                            color:
+                                palette.onSurfaceVariant.withValues(alpha: 0.6),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      resultText,
+                      style: GoogleFonts.spaceGrotesk(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: resultColor,
+                      ),
+                      // Compound-interest rows are long; two lines beats
+                      // truncating the answer mid-number.
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+
+              // Actions
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _IconAction(
+                    icon: history.isPinned
+                        ? Icons.push_pin_rounded
+                        : Icons.push_pin_outlined,
+                    color: history.isPinned
+                        ? palette.pinned
+                        : palette.onSurfaceVariant,
+                    tooltip: history.isPinned ? 'Unpin' : 'Pin',
+                    onTap: onPin,
+                  ),
+                  _IconAction(
+                    icon: Icons.delete_outline_rounded,
+                    color: palette.onSurfaceVariant,
+                    tooltip: 'Delete',
+                    onTap: onDelete,
+                  ),
+                ],
               ),
             ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -287,48 +468,125 @@ class _HistoryCard extends StatelessWidget {
         return '=';
       case 'compound_interest':
         return '%';
+      case 'emi':
+        return '₹/m';
+      case 'loan_payoff':
+        return '⏱';
+      case 'investment_sip':
+        return 'SIP';
+      case 'investment_roi':
+        return '↗';
       default:
         return '?';
     }
   }
 
-  Color _getAvatarColor() {
+  Color _getAvatarColor(AppPalette palette) {
     switch (history.type) {
       case 'basic_calculator':
-        return AppTheme.primary;
+        return palette.primary;
       case 'compound_interest':
-        return AppTheme.green;
+      case 'loan_payoff':
+      case 'investment_sip':
+      case 'investment_roi':
+        return palette.green;
+      case 'emi':
+        return const Color(0xFFFF9800);
       default:
-        return AppTheme.onSurfaceVariant;
+        return palette.onSurfaceVariant;
     }
   }
 
-  Color _getResultColor() {
+  Color _getResultColor(AppPalette palette) {
     switch (history.type) {
       case 'basic_calculator':
-        return const Color(0xFF4CAF50);
+        return palette.green;
       case 'compound_interest':
-        return AppTheme.primary;
+      case 'emi':
+      case 'loan_payoff':
+      case 'investment_sip':
+      case 'investment_roi':
+        return palette.primary;
       default:
-        return AppTheme.onSurface;
+        return palette.onSurface;
     }
   }
 
   String _getResultText() {
     switch (history.type) {
       case 'basic_calculator':
-        final prev = history.inputs['previousValue'] ?? '';
-        final op = history.inputs['operator'] ?? '';
-        final current = history.inputs['currentValue'] ?? '';
-        final result = history.results['result'] ?? '';
-        return '$prev $op $current = $result';
+        final result = history.results['result'];
+        // Rows written before the schema change stored the operands
+        // separately and never stored a result.
+        final expression = history.inputs['expression'] ??
+            [
+              history.inputs['previousValue'],
+              history.inputs['operator'],
+              history.inputs['currentValue'],
+            ].where((e) => e != null && '$e'.isNotEmpty).join(' ');
+        if (result == null || '$result'.isEmpty) return '$expression = ?';
+        return '$expression = $result';
       case 'compound_interest':
         final principal = history.inputs['principal'] ?? '';
         final finalAmount = history.results['finalAmount'] ?? '';
         final interest = history.results['interestEarned'] ?? '';
         return '₹$principal → ₹$finalAmount  (+$interest)';
+      case 'emi':
+        final emi = history.results['emi'] ?? '';
+        final principal = history.inputs['principal'] ?? '';
+        final interest = history.results['totalInterest'] ?? '';
+        return '₹$principal → ₹$emi/mo  (interest ₹$interest)';
+      case 'loan_payoff':
+        final payoff = history.results['payoff'] ?? '';
+        final saved = history.results['interestSaved'] ?? '';
+        final emi = history.results['emi'] ?? '';
+        final monthsSaved = history.results['monthsSaved'];
+        if (monthsSaved is int && monthsSaved > 0) {
+          return 'Clears in $payoff · saves ₹$saved';
+        }
+        return 'Runs $payoff at ₹$emi/mo';
+      case 'investment_sip':
+        final monthly = history.inputs['monthly'] ?? '';
+        final maturity = history.results['maturity'] ?? '';
+        final gain = history.results['gain'] ?? '';
+        return '₹$monthly/mo → ₹$maturity  (+₹$gain)';
+      case 'investment_roi':
+        final cagr = history.results['cagr'] ?? '';
+        final absolute = history.results['absoluteReturn'] ?? '';
+        final invested = history.inputs['invested'] ?? '';
+        final current = history.inputs['currentValue'] ?? '';
+        return '₹$invested → ₹$current  ($cagr CAGR, $absolute)';
       default:
         return history.results.toString();
     }
+  }
+}
+
+class _IconAction extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  const _IconAction({
+    required this.icon,
+    required this.color,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: InkResponse(
+        onTap: onTap,
+        radius: 22,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Icon(icon, size: 18, color: color),
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/investment_returns_screen.dart
+++ b/lib/screens/investment_returns_screen.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app/theme.dart';
+import '../providers/history_provider.dart';
+import '../utils/database_helper.dart';
+import '../utils/finance.dart';
+import '../utils/money.dart';
+import '../widgets/finance_widgets.dart';
+
+/// Two questions in one screen: what a monthly SIP will grow into, and what a
+/// holding you already own has actually returned.
+class InvestmentReturnsScreen extends StatefulWidget {
+  const InvestmentReturnsScreen({super.key});
+
+  static const List<Color> accent = [Color(0xFF9C27B0), Color(0xFF4A148C)];
+
+  @override
+  State<InvestmentReturnsScreen> createState() =>
+      _InvestmentReturnsScreenState();
+}
+
+enum _Mode { sip, realised }
+
+class _InvestmentReturnsScreenState extends State<InvestmentReturnsScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _resultKey = GlobalKey();
+
+  // SIP
+  final _monthlyController = TextEditingController();
+  final _rateController = TextEditingController();
+  final _sipYearsController = TextEditingController();
+
+  // Realised return
+  final _investedController = TextEditingController();
+  final _currentController = TextEditingController();
+  final _heldYearsController = TextEditingController();
+
+  _Mode _mode = _Mode.sip;
+  SipResult? _sip;
+  RoiResult? _roi;
+
+  @override
+  void dispose() {
+    _monthlyController.dispose();
+    _rateController.dispose();
+    _sipYearsController.dispose();
+    _investedController.dispose();
+    _currentController.dispose();
+    _heldYearsController.dispose();
+    super.dispose();
+  }
+
+  void _setMode(_Mode mode) {
+    if (mode == _mode) return;
+    setState(() {
+      _mode = mode;
+      // Results from the other mode would be stale and confusing.
+      _sip = null;
+      _roi = null;
+    });
+  }
+
+  void _calculate() {
+    FocusScope.of(context).unfocus();
+    if (!_formKey.currentState!.validate()) return;
+
+    if (_mode == _Mode.sip) {
+      final result = calculateSip(
+        monthly: double.parse(_monthlyController.text.replaceAll(',', '')),
+        annualRatePercent: double.parse(_rateController.text),
+        years: double.parse(_sipYearsController.text),
+      );
+      setState(() {
+        _sip = result;
+        _roi = null;
+      });
+      _saveSip(result);
+    } else {
+      final result = calculateRoi(
+        invested: double.parse(_investedController.text.replaceAll(',', '')),
+        currentValue: double.parse(_currentController.text.replaceAll(',', '')),
+        years: double.parse(_heldYearsController.text),
+      );
+      setState(() {
+        _roi = result;
+        _sip = null;
+      });
+      _saveRoi(result);
+    }
+    _revealResult();
+  }
+
+  void _revealResult() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _resultKey.currentContext;
+      if (ctx == null || !mounted) return;
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeOutCubic,
+        alignment: 0.05,
+      );
+    });
+  }
+
+  void _saveSip(SipResult result) {
+    context.read<HistoryProvider>().addHistory(
+          CalculationHistory(
+            type: 'investment_sip',
+            name: 'SIP Projection',
+            label: 'finance',
+            isPinned: false,
+            timestamp: DateTime.now(),
+            inputs: {
+              'monthly': money(result.monthly),
+              'rate': '${_rateController.text}%',
+              'years': _sipYearsController.text,
+            },
+            results: {
+              'maturity': money(result.maturity),
+              'invested': money(result.invested),
+              'gain': money(result.gain),
+            },
+          ),
+        );
+  }
+
+  void _saveRoi(RoiResult result) {
+    context.read<HistoryProvider>().addHistory(
+          CalculationHistory(
+            type: 'investment_roi',
+            name: 'Investment Return',
+            label: 'finance',
+            isPinned: false,
+            timestamp: DateTime.now(),
+            inputs: {
+              'invested': money(result.invested),
+              'currentValue': money(result.currentValue),
+              'years': _heldYearsController.text,
+            },
+            results: {
+              'cagr': percent(result.cagr),
+              'absoluteReturn': signedPercent(result.absoluteReturn),
+              'profit': money(result.profit),
+            },
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FinanceScaffold(
+      title: 'Investment Returns',
+      heroSubtitle: _mode == _Mode.sip
+          ? 'What a monthly SIP grows into'
+          : 'What a holding has actually returned',
+      icon: Icons.show_chart_rounded,
+      accent: InvestmentReturnsScreen.accent,
+      formKey: _formKey,
+      onCalculate: _calculate,
+      ctaLabel: _mode == _Mode.sip ? 'Project' : 'Calculate',
+      fields: [
+        SegmentedSelector<_Mode>(
+          options: const [
+            (label: 'SIP', value: _Mode.sip),
+            (label: 'Returns', value: _Mode.realised),
+          ],
+          selected: _mode,
+          onChanged: _setMode,
+        ),
+        const SizedBox(height: 16),
+        if (_mode == _Mode.sip) ..._sipFields() else ..._roiFields(),
+      ],
+      resultKey: _resultKey,
+      results: _results(context),
+    );
+  }
+
+  List<Widget> _sipFields() => [
+        MoneyField(
+          key: const ValueKey('sip-monthly'),
+          controller: _monthlyController,
+          label: 'Monthly Investment',
+          hint: '10,000',
+          prefix: '₹',
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          key: const ValueKey('sip-rate'),
+          controller: _rateController,
+          label: 'Expected Return',
+          hint: '12.0',
+          suffix: '% p.a.',
+          allowDecimal: true,
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          key: const ValueKey('sip-years'),
+          controller: _sipYearsController,
+          label: 'Duration',
+          hint: '10',
+          suffix: 'yrs',
+          allowDecimal: true,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => _calculate(),
+          extraValidator: (value) => value > 50 ? 'Maximum 50 years' : null,
+        ),
+      ];
+
+  List<Widget> _roiFields() => [
+        MoneyField(
+          key: const ValueKey('roi-invested'),
+          controller: _investedController,
+          label: 'Amount Invested',
+          hint: '1,00,000',
+          prefix: '₹',
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          key: const ValueKey('roi-current'),
+          controller: _currentController,
+          label: 'Value Today',
+          hint: '2,50,000',
+          prefix: '₹',
+          allowDecimal: true,
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          key: const ValueKey('roi-years'),
+          controller: _heldYearsController,
+          label: 'Held For',
+          hint: '5',
+          suffix: 'yrs',
+          allowDecimal: true,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => _calculate(),
+          extraValidator: (value) => value > 100 ? 'Maximum 100 years' : null,
+        ),
+      ];
+
+  List<Widget> _results(BuildContext context) {
+    final palette = context.palette;
+
+    final sip = _sip;
+    if (sip != null) {
+      return [
+        HeadlineResult(
+          key: _resultKey,
+          label: 'Maturity Value',
+          value: rupees(sip.maturity),
+          stats: [
+            (
+              label: 'Invested',
+              value: rupees(sip.invested),
+              color: palette.onSurfaceVariant,
+            ),
+            (
+              label: 'Gain',
+              value: '${rupees(sip.gain)} (${signedPercent(sip.gainRatio)})',
+              color: palette.green,
+            ),
+          ],
+          footnote: '${formatMonths(sip.months)} of monthly contributions',
+        ),
+        const SizedBox(height: 12),
+        SplitBar(
+          leftLabel: 'Invested ${rupees(sip.invested)}',
+          rightLabel: 'Gain ${rupees(sip.gain)}',
+          leftFraction:
+              sip.maturity == 0 ? 1 : sip.invested / sip.maturity,
+          leftColor: palette.primary,
+          rightColor: palette.green,
+        ),
+        const SizedBox(height: 12),
+        BreakdownTable(
+          title: 'Year-by-Year Growth',
+          columns: const [
+            (label: 'Yr', flex: 1),
+            (label: 'Invested', flex: 2),
+            (label: 'Value', flex: 2),
+            (label: 'Gain', flex: 2),
+          ],
+          rows: [
+            for (final row in sip.schedule)
+              [
+                '${row.year}',
+                moneyWhole(row.invested),
+                moneyWhole(row.value),
+                moneyWhole(row.gain),
+              ],
+          ],
+          accentColumn: 3,
+          accentColor: palette.green,
+        ),
+      ];
+    }
+
+    final roi = _roi;
+    if (roi != null) {
+      final tone = roi.isLoss ? palette.error : palette.green;
+      return [
+        HeadlineResult(
+          key: _resultKey,
+          label: 'Annualised Return (CAGR)',
+          value: signedPercent(roi.cagr, decimals: 2),
+          valueColor: tone,
+          stats: [
+            (
+              label: 'Invested',
+              value: rupees(roi.invested),
+              color: palette.onSurfaceVariant,
+            ),
+            (
+              label: 'Value today',
+              value: rupees(roi.currentValue),
+              color: palette.onSurface,
+            ),
+            (
+              label: roi.isLoss ? 'Loss' : 'Profit',
+              value: rupees(roi.profit.abs()),
+              color: tone,
+            ),
+            (
+              label: 'Total return',
+              value: signedPercent(roi.absoluteReturn),
+              color: tone,
+            ),
+          ],
+          footnote: roi.isLoss
+              ? 'Down ${signedPercent(roi.absoluteReturn)} '
+                  'over ${years(roi.years)} yr'
+              : 'Grew ${(roi.currentValue / roi.invested).toStringAsFixed(2)}× '
+                  'over ${years(roi.years)} yr',
+        ),
+      ];
+    }
+
+    return const [];
+  }
+}

--- a/lib/screens/loan_calculator_screen.dart
+++ b/lib/screens/loan_calculator_screen.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app/theme.dart';
+import '../providers/history_provider.dart';
+import '../utils/database_helper.dart';
+import '../utils/finance.dart';
+import '../utils/money.dart';
+import '../widgets/app_snackbar.dart';
+import '../widgets/finance_widgets.dart';
+
+/// "If I pay extra on top of my EMI, how much sooner is the loan over?"
+class LoanCalculatorScreen extends StatefulWidget {
+  const LoanCalculatorScreen({super.key});
+
+  static const List<Color> accent = [Color(0xFF2196F3), Color(0xFF0D47A1)];
+
+  @override
+  State<LoanCalculatorScreen> createState() => _LoanCalculatorScreenState();
+}
+
+class _LoanCalculatorScreenState extends State<LoanCalculatorScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountController = TextEditingController();
+  final _rateController = TextEditingController();
+  final _yearsController = TextEditingController();
+  final _extraController = TextEditingController();
+  final _resultKey = GlobalKey();
+
+  ExtraPaymentFrequency _frequency = ExtraPaymentFrequency.yearly;
+  LoanPayoffResult? _result;
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _rateController.dispose();
+    _yearsController.dispose();
+    _extraController.dispose();
+    super.dispose();
+  }
+
+  void _calculate() {
+    FocusScope.of(context).unfocus();
+    if (!_formKey.currentState!.validate()) return;
+
+    final extraText = _extraController.text.replaceAll(',', '');
+    final extra = extraText.isEmpty ? 0.0 : double.parse(extraText);
+
+    try {
+      final result = calculateLoanPayoff(
+        principal: double.parse(_amountController.text.replaceAll(',', '')),
+        annualRatePercent: double.parse(_rateController.text),
+        months: (double.parse(_yearsController.text) * 12).round(),
+        extraAmount: extra,
+        frequency: _frequency,
+      );
+      setState(() => _result = result);
+      _saveToHistory(result);
+      _revealResult();
+    } on LoanNeverAmortisesError catch (e) {
+      setState(() => _result = null);
+      showAppSnackBar(context, e.message);
+    }
+  }
+
+  void _revealResult() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _resultKey.currentContext;
+      if (ctx == null || !mounted) return;
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeOutCubic,
+        alignment: 0.05,
+      );
+    });
+  }
+
+  void _saveToHistory(LoanPayoffResult result) {
+    final now = DateTime.now();
+    context.read<HistoryProvider>().addHistory(
+          CalculationHistory(
+            type: 'loan_payoff',
+            name: 'Loan Payoff',
+            label: 'finance',
+            isPinned: false,
+            timestamp: now,
+            inputs: {
+              'principal': money(result.principal),
+              'rate': '${_rateController.text}%',
+              'months': result.baselineMonths,
+              'extra': money(result.totalExtraPaid),
+              'frequency': _frequency.name,
+            },
+            results: {
+              'emi': money(result.emi),
+              'payoff': formatMonths(result.payoffMonths),
+              'monthsSaved': result.monthsSaved,
+              'interestSaved': money(result.interestSaved),
+            },
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = _result;
+
+    return FinanceScaffold(
+      title: 'Loan Payoff',
+      heroSubtitle: 'Pay extra, finish early',
+      icon: Icons.account_balance_outlined,
+      accent: LoanCalculatorScreen.accent,
+      formKey: _formKey,
+      onCalculate: _calculate,
+      ctaLabel: 'See payoff',
+      fields: [
+        MoneyField(
+          controller: _amountController,
+          label: 'Loan Amount',
+          hint: '10,00,000',
+          prefix: '₹',
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          controller: _rateController,
+          label: 'Interest Rate',
+          hint: '9.0',
+          suffix: '% p.a.',
+          allowDecimal: true,
+        ),
+        const SizedBox(height: 16),
+        MoneyField(
+          controller: _yearsController,
+          label: 'Original Tenure',
+          hint: '20',
+          suffix: 'yrs',
+          allowDecimal: true,
+          extraValidator: (value) =>
+              value > 50 ? 'Maximum 50 years' : null,
+        ),
+        const SizedBox(height: 16),
+        SegmentedSelector<ExtraPaymentFrequency>(
+          label: 'Extra payment',
+          options: const [
+            (label: 'Every year', value: ExtraPaymentFrequency.yearly),
+            (label: 'Every month', value: ExtraPaymentFrequency.monthly),
+          ],
+          selected: _frequency,
+          onChanged: (value) => setState(() => _frequency = value),
+        ),
+        const SizedBox(height: 16),
+        OptionalMoneyField(
+          controller: _extraController,
+          label: _frequency == ExtraPaymentFrequency.yearly
+              ? 'Extra paid each year'
+              : 'Extra paid each month',
+          hint: 'Leave blank for none',
+          prefix: '₹',
+        ),
+      ],
+      resultKey: _resultKey,
+      results: result == null ? const [] : _results(context, result),
+    );
+  }
+
+  List<Widget> _results(BuildContext context, LoanPayoffResult result) {
+    final palette = context.palette;
+
+    return [
+      HeadlineResult(
+        key: _resultKey,
+        label: result.hasExtra ? 'Loan clears in' : 'Loan runs for',
+        value: formatMonths(result.payoffMonths),
+        valueColor: result.hasExtra ? palette.green : palette.primary,
+        stats: [
+          (
+            label: 'Monthly EMI',
+            value: rupees(result.emi),
+            color: palette.onSurface,
+          ),
+          (
+            label: 'Interest paid',
+            value: rupees(result.actualInterest),
+            color: palette.error,
+          ),
+          if (result.hasExtra) ...[
+            (
+              label: 'Time saved',
+              value: formatMonths(result.monthsSaved),
+              color: palette.green,
+            ),
+            (
+              label: 'Interest saved',
+              value: rupees(result.interestSaved),
+              color: palette.green,
+            ),
+          ] else ...[
+            (
+              label: 'Total repaid',
+              value: rupees(result.principal + result.actualInterest),
+              color: palette.onSurfaceVariant,
+            ),
+            (
+              label: 'Original tenure',
+              value: formatMonths(result.baselineMonths),
+              color: palette.onSurfaceVariant,
+            ),
+          ],
+        ],
+        footnote: result.hasExtra
+            ? 'Paying ${rupees(result.totalExtraPaid)} extra in total clears '
+                'the loan ${formatMonths(result.monthsSaved)} early'
+            : 'Add an extra payment above to see how much sooner it ends',
+      ),
+      if (result.hasExtra) ...[
+        const SizedBox(height: 12),
+        SplitBar(
+          leftLabel: 'Paid ${formatMonths(result.payoffMonths)}',
+          rightLabel: 'Saved ${formatMonths(result.monthsSaved)}',
+          leftFraction: result.payoffMonths / result.baselineMonths,
+          leftColor: palette.primary,
+          rightColor: palette.green,
+        ),
+      ],
+      const SizedBox(height: 12),
+      BreakdownTable(
+        title: 'Year-by-Year Balance',
+        columns: const [
+          (label: 'Yr', flex: 1),
+          (label: 'Principal', flex: 2),
+          (label: 'Interest', flex: 2),
+          (label: 'Balance', flex: 2),
+        ],
+        rows: [
+          for (final row in result.schedule)
+            [
+              '${row.year}',
+              moneyWhole(row.principalPaid + row.extraPaid),
+              moneyWhole(row.interestPaid),
+              moneyWhole(row.closingBalance),
+            ],
+        ],
+        accentColumn: 2,
+        accentColor: palette.error,
+        footnote: result.hasExtra
+            ? 'Principal column includes the extra payments.'
+            : null,
+      ),
+    ];
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,39 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../app/theme.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+
     return Scaffold(
+      backgroundColor: palette.background,
       appBar: AppBar(
-        title: const Text('Settings'),
+        backgroundColor: Colors.transparent,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_ios_new_rounded,
+              color: palette.onSurface, size: 20),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: Text(
+          'Settings',
+          style: GoogleFonts.spaceGrotesk(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: palette.onSurface,
+          ),
+        ),
       ),
       body: ListView(
+        padding: const EdgeInsets.all(16),
         children: [
-          ListTile(
-            leading: const Icon(Icons.palette),
-            title: const Text('Theme'),
-            subtitle: const Text('Change app appearance'),
-            onTap: () {
-              // TODO: Implement theme settings
-            },
+          _tile(
+            context,
+            icon: Icons.palette_outlined,
+            title: 'Theme',
+            subtitle: 'Use the sun/moon button in the header',
           ),
-          ListTile(
-            leading: const Icon(Icons.history),
-            title: const Text('History'),
-            subtitle: const Text('Manage calculation history'),
-            onTap: () {
-              // TODO: Implement history settings
-            },
+          const SizedBox(height: 10),
+          _tile(
+            context,
+            icon: Icons.history_outlined,
+            title: 'History',
+            subtitle: 'Pin, delete or clear entries from the History tab',
           ),
-          ListTile(
-            leading: const Icon(Icons.info),
-            title: const Text('About'),
-            subtitle: const Text('App information and credits'),
-            onTap: () {
-              // TODO: Implement about screen
-            },
+          const SizedBox(height: 10),
+          _tile(
+            context,
+            icon: Icons.info_outline_rounded,
+            title: 'About',
+            subtitle: 'Life Mathematics',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _tile(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+  }) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: palette.surfaceContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: palette.primary),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: GoogleFonts.spaceGrotesk(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: palette.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: GoogleFonts.manrope(
+                    fontSize: 11,
+                    color: palette.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/screens/smart_calculators_screen.dart
+++ b/lib/screens/smart_calculators_screen.dart
@@ -3,14 +3,19 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../app/theme.dart';
 import 'compound_interest_screen.dart';
+import 'emi_calculator_screen.dart';
+import 'investment_returns_screen.dart';
+import 'loan_calculator_screen.dart';
 
 class SmartCalculatorsScreen extends StatelessWidget {
   const SmartCalculatorsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+
     return SingleChildScrollView(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -20,7 +25,7 @@ class SmartCalculatorsScreen extends StatelessWidget {
               'Choose a calculator',
               style: GoogleFonts.manrope(
                 fontSize: 13,
-                color: AppTheme.onSurfaceVariant,
+                color: palette.onSurfaceVariant,
                 letterSpacing: 0.5,
               ),
             ),
@@ -45,25 +50,40 @@ class SmartCalculatorsScreen extends StatelessWidget {
                 ),
               ),
               _CalcCard(
-                title: 'Loan\nCalculator',
-                subtitle: 'Plan your debt',
-                gradientColors: const [Color(0xFF2196F3), Color(0xFF0D47A1)],
+                title: 'Loan\nPayoff',
+                subtitle: 'Finish early',
+                gradientColors: LoanCalculatorScreen.accent,
                 icon: Icons.account_balance_outlined,
-                onTap: () => _comingSoon(context),
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const LoanCalculatorScreen(),
+                  ),
+                ),
               ),
               _CalcCard(
                 title: 'EMI\nCalculator',
                 subtitle: 'Monthly payments',
-                gradientColors: const [Color(0xFFFF9800), Color(0xFFE65100)],
+                gradientColors: EmiCalculatorScreen.accent,
                 icon: Icons.payments_outlined,
-                onTap: () => _comingSoon(context),
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EmiCalculatorScreen(),
+                  ),
+                ),
               ),
               _CalcCard(
                 title: 'Investment\nReturns',
-                subtitle: 'Track your ROI',
-                gradientColors: const [Color(0xFF9C27B0), Color(0xFF4A148C)],
+                subtitle: 'SIP and ROI',
+                gradientColors: InvestmentReturnsScreen.accent,
                 icon: Icons.show_chart_rounded,
-                onTap: () => _comingSoon(context),
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const InvestmentReturnsScreen(),
+                  ),
+                ),
               ),
             ],
           ),
@@ -72,19 +92,6 @@ class SmartCalculatorsScreen extends StatelessWidget {
     );
   }
 
-  void _comingSoon(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          'Coming soon!',
-          style: GoogleFonts.manrope(color: Colors.white),
-        ),
-        backgroundColor: AppTheme.surfaceContainerHighest,
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      ),
-    );
-  }
 }
 
 class _CalcCard extends StatelessWidget {
@@ -104,61 +111,70 @@ class _CalcCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.all(18),
-        decoration: BoxDecoration(
-          color: AppTheme.surfaceContainer,
+    final palette = context.palette;
+
+    return Semantics(
+      button: true,
+      label: title.replaceAll('\n', ' '),
+      child: Material(
+        color: palette.surfaceContainer,
+        borderRadius: BorderRadius.circular(24),
+        child: InkWell(
+          onTap: onTap,
           borderRadius: BorderRadius.circular(24),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Gradient icon circle
-            Container(
-              width: 52,
-              height: 52,
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: gradientColors,
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                ),
-                shape: BoxShape.circle,
-              ),
-              child: Icon(icon, color: Colors.white, size: 26),
-            ),
-            const Spacer(),
-            Text(
-              title,
-              style: GoogleFonts.spaceGrotesk(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: AppTheme.onSurface,
-                height: 1.2,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Row(
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(
-                  child: Text(
-                    subtitle,
-                    style: GoogleFonts.manrope(
-                      fontSize: 11,
-                      color: AppTheme.onSurfaceVariant,
+                // Gradient icon circle
+                Container(
+                  width: 52,
+                  height: 52,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: gradientColors,
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
                     ),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(icon, color: Colors.white, size: 26),
+                ),
+                const Spacer(),
+                Text(
+                  title,
+                  style: GoogleFonts.spaceGrotesk(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: palette.onSurface,
+                    height: 1.2,
                   ),
                 ),
-                const Icon(
-                  Icons.arrow_forward_ios_rounded,
-                  size: 12,
-                  color: AppTheme.onSurfaceVariant,
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        subtitle,
+                        style: GoogleFonts.manrope(
+                          fontSize: 11,
+                          color: palette.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Icon(
+                      Icons.arrow_forward_ios_rounded,
+                      size: 12,
+                      color: palette.onSurfaceVariant,
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/utils/calculator_logic.dart
+++ b/lib/utils/calculator_logic.dart
@@ -1,4 +1,28 @@
+/// A completed calculation, ready to be shown or persisted.
+typedef Calculation = ({String expression, String result});
+
 class CalculatorLogic {
+  /// Longest number a user may type. Doubles carry ~15-17 significant digits,
+  /// so anything beyond this is noise the display would silently round away.
+  static const int maxInputDigits = 15;
+
+  /// Above this magnitude a plain decimal string is unreadable (and
+  /// `toStringAsFixed` silently falls back to `toString`), so we switch to
+  /// scientific notation deliberately rather than by accident.
+  static const double _scientificThreshold = 1e15;
+
+  static const String errorText = 'Error';
+
+  /// Oldest tape tokens are dropped past this, so a long session cannot grow
+  /// without bound.
+  static const int _maxTapeTokens = 400;
+
+  /// Longest expression persisted to history; longer chains are elided from
+  /// the front so the most recent steps survive.
+  static const int _maxExpressionChars = 240;
+
+  static const String _tapeBreak = '\n';
+
   String _displayValue = '0';
   String _previousValue = '';
   String _operator = '';
@@ -6,11 +30,65 @@ class CalculatorLogic {
   bool _hasDecimal = false;
   String _lastExpression = '';
   String _fullResult = '';
+  bool _hasError = false;
+  Calculation? _lastCalculation;
+
+  /// Every operand and operator entered since the last [clear], in order.
+  /// Chained arithmetic collapses to a running total, so without this the
+  /// earlier steps of a long calculation are unrecoverable.
+  final List<String> _tape = [];
+  bool _tapeBreakPending = false;
+  int _tapeUndoCount = 0;
+  bool _lastOperatorEvaluated = false;
 
   String get displayValue => _displayValue;
   String get fullResult => _fullResult;
   String get previousValue => _previousValue;
   String get currentOperator => _operator;
+  bool get hasError => _hasError;
+
+  /// The full running tape, e.g. `12 + 8 − 5 × 3 = 45`. Empty until the first
+  /// operator is pressed; survives `=` and `CE`, cleared only by `C`.
+  String get tape {
+    final buffer = StringBuffer();
+    var atLineStart = true;
+    for (final token in _tape) {
+      if (token == _tapeBreak) {
+        buffer.write('\n');
+        atLineStart = true;
+        continue;
+      }
+      if (!atLineStart) buffer.write(' ');
+      buffer.write(token);
+      atLineStart = false;
+    }
+    return buffer.toString();
+  }
+
+  /// The tape's current line, i.e. everything since the last line break.
+  /// This is what gets persisted, so history records the whole chain rather
+  /// than the running total and the final operand.
+  String _currentLineText() {
+    final start = _tape.lastIndexOf(_tapeBreak) + 1;
+    final text = _tape.sublist(start).join(' ');
+    if (text.length <= _maxExpressionChars) return text;
+    return '…${text.substring(text.length - _maxExpressionChars)}';
+  }
+
+  void _pushTape(String token) {
+    if (_tapeBreakPending) {
+      _tapeBreakPending = false;
+      if (_tape.isNotEmpty) _tape.add(_tapeBreak);
+    }
+    _tape.add(token);
+    if (_tape.length > _maxTapeTokens) {
+      _tape.removeRange(0, _tape.length - _maxTapeTokens);
+    }
+  }
+
+  /// The most recent completed `=`, or null if nothing has been evaluated
+  /// since the last clear. Consumed by the history writer.
+  Calculation? get lastCalculation => _lastCalculation;
 
   bool get isResultTruncated =>
       _fullResult.isNotEmpty && _fullResult != _displayValue;
@@ -28,16 +106,31 @@ class CalculatorLogic {
     return _lastExpression;
   }
 
+  /// Digits actually entered, ignoring sign and decimal point.
+  int get _digitCount =>
+      _displayValue.replaceAll(RegExp(r'[^0-9]'), '').length;
+
+  /// True when typing would begin a term unrelated to what the tape already
+  /// holds — i.e. straight after `=`. The next tape entry starts a new line.
+  bool get _startsDetachedTerm =>
+      _shouldResetDisplay && _operator.isEmpty && _tape.isNotEmpty;
+
   void inputNumber(String number) {
+    if (_hasError) clear();
     _fullResult = '';
     if (_shouldResetDisplay) {
+      if (_startsDetachedTerm) _tapeBreakPending = true;
       _lastExpression = '';
+      _lastCalculation = null;
       _displayValue = number;
       _shouldResetDisplay = false;
       _hasDecimal = false;
     } else {
-      if (_displayValue == '0' && number != '.') {
+      if (_digitCount >= maxInputDigits) return;
+      if (_displayValue == '0') {
         _displayValue = number;
+      } else if (_displayValue == '-0') {
+        _displayValue = '-$number';
       } else {
         _displayValue += number;
       }
@@ -45,9 +138,12 @@ class CalculatorLogic {
   }
 
   void inputDecimal() {
+    if (_hasError) clear();
     _fullResult = '';
     if (_shouldResetDisplay) {
+      if (_startsDetachedTerm) _tapeBreakPending = true;
       _lastExpression = '';
+      _lastCalculation = null;
       _displayValue = '0.';
       _shouldResetDisplay = false;
       _hasDecimal = true;
@@ -58,10 +154,38 @@ class CalculatorLogic {
   }
 
   void inputOperator(String op) {
-    if (_previousValue.isNotEmpty && !_shouldResetDisplay) {
-      calculate();
+    // An operator applied to a failed calculation used to coerce "Error" to 0
+    // and quietly produce a wrong answer. Refuse instead.
+    if (_hasError) return;
+
+    // Operator pressed twice running: swap it instead of opening a new term.
+    if (_shouldResetDisplay && _operator.isNotEmpty) {
+      if (_tape.isNotEmpty) _tape[_tape.length - 1] = op;
+      _operator = op;
+      return;
     }
+
+    // Straight after `=` the tape already ends with the result, so only the
+    // operator is new.
+    final continuesFromResult = _startsDetachedTerm;
+    final operand = _displayValue;
+    final evaluated = _previousValue.isNotEmpty && !_shouldResetDisplay;
+
+    if (evaluated) {
+      _evaluate();
+      if (_hasError) return;
+    }
+
+    if (!continuesFromResult) _pushTape(operand);
+    _pushTape(op);
+
+    // Backspace can only take back the operator once the operand has been
+    // folded into the running total — that term is already spent.
+    _lastOperatorEvaluated = evaluated || continuesFromResult;
+    _tapeUndoCount = _lastOperatorEvaluated ? 1 : 2;
+
     _lastExpression = '';
+    _lastCalculation = null;
     _fullResult = '';
     _previousValue = _displayValue;
     _operator = op;
@@ -70,11 +194,35 @@ class CalculatorLogic {
   }
 
   void calculate() {
+    if (_hasError) return;
     if (_previousValue.isEmpty || _operator.isEmpty) return;
 
-    double prev = double.tryParse(_previousValue) ?? 0;
-    double current = double.tryParse(_displayValue) ?? 0;
-    double result = 0;
+    final operand = _displayValue;
+    _evaluate();
+
+    _pushTape(operand);
+    // Captured before the "= result" tokens land, so history stores the whole
+    // chain — "1 + 2 + 3", not the running total plus the last operand.
+    final chain = _currentLineText();
+    _pushTape('=');
+    _pushTape(_hasError ? errorText : _displayValue);
+    _tapeUndoCount = 0;
+
+    if (!_hasError) {
+      _lastCalculation = (expression: chain, result: _displayValue);
+    }
+  }
+
+  void _evaluate() {
+    final double? prev = double.tryParse(_previousValue);
+    final double? current = double.tryParse(_displayValue);
+    if (prev == null || current == null) {
+      _fail();
+      return;
+    }
+
+    final String expressionText = '$_previousValue $_operator $_displayValue';
+    double result;
 
     switch (_operator) {
       case '+':
@@ -88,38 +236,78 @@ class CalculatorLogic {
         break;
       case '÷':
         if (current == 0) {
-          _displayValue = 'Error';
-          _lastExpression = '';
-          _clear();
+          _fail();
           return;
         }
         result = prev / current;
         break;
-      case '%':
-        result = prev * (current / 100);
-        break;
+      default:
+        _fail();
+        return;
     }
 
-    _lastExpression = '$_previousValue $_operator $_displayValue =';
-
-    if (result == result.toInt()) {
-      _displayValue = result.toInt().toString();
-      _fullResult = '';
-    } else {
-      // Full precision (up to 10 significant decimal places)
-      final fullStr =
-          result.toStringAsFixed(10).replaceAll(RegExp(r'\.?0+$'), '');
-      // Truncated to 4 decimal places
-      final truncated =
-          result.toStringAsFixed(4).replaceAll(RegExp(r'\.?0+$'), '');
-      _displayValue = truncated;
-      _fullResult = (fullStr != truncated) ? fullStr : '';
+    if (!result.isFinite) {
+      _fail();
+      return;
     }
+
+    _lastExpression = '$expressionText =';
+
+    final formatted = _format(result);
+    _displayValue = formatted.short;
+    _fullResult = formatted.long != formatted.short ? formatted.long : '';
+
+    _lastCalculation = (expression: expressionText, result: _displayValue);
 
     _previousValue = '';
     _operator = '';
     _shouldResetDisplay = true;
     _hasDecimal = _displayValue.contains('.');
+  }
+
+  /// Renders a result twice: a compact form for the display, and a
+  /// higher-precision form behind the expand toggle.
+  ({String short, String long}) _format(double value) {
+    final magnitude = value.abs();
+
+    if (magnitude >= _scientificThreshold ||
+        (magnitude > 0 && magnitude < 1e-9)) {
+      return (
+        short: _trimExponential(value.toStringAsExponential(4)),
+        long: _trimExponential(value.toStringAsExponential(12)),
+      );
+    }
+
+    if (value == value.roundToDouble()) {
+      final whole = value.toInt().toString();
+      return (short: whole, long: whole);
+    }
+
+    final long = _trimZeros(value.toStringAsFixed(10));
+    final short = _trimZeros(value.toStringAsFixed(4));
+    return (short: short, long: long);
+  }
+
+  static String _trimZeros(String s) =>
+      s.contains('.') ? s.replaceAll(RegExp(r'0+$'), '').replaceAll(RegExp(r'\.$'), '') : s;
+
+  /// `9.0000e+22` → `9e+22`, keeping the exponent intact.
+  static String _trimExponential(String s) {
+    final parts = s.split('e');
+    if (parts.length != 2) return s;
+    return '${_trimZeros(parts[0])}e${parts[1]}';
+  }
+
+  void _fail() {
+    _displayValue = errorText;
+    _previousValue = '';
+    _operator = '';
+    _lastExpression = '';
+    _fullResult = '';
+    _lastCalculation = null;
+    _shouldResetDisplay = true;
+    _hasDecimal = false;
+    _hasError = true;
   }
 
   void clear() {
@@ -130,15 +318,18 @@ class CalculatorLogic {
     _hasDecimal = false;
     _lastExpression = '';
     _fullResult = '';
-  }
-
-  void _clear() {
-    _previousValue = '';
-    _operator = '';
-    _shouldResetDisplay = true;
+    _hasError = false;
+    _lastCalculation = null;
+    _tape.clear();
+    _tapeBreakPending = false;
+    _tapeUndoCount = 0;
   }
 
   void clearEntry() {
+    if (_hasError) {
+      clear();
+      return;
+    }
     _displayValue = '0';
     _shouldResetDisplay = false;
     _hasDecimal = false;
@@ -146,20 +337,39 @@ class CalculatorLogic {
   }
 
   void backspace() {
+    if (_hasError) {
+      clear();
+      return;
+    }
     _fullResult = '';
     _lastExpression = '';
+    _lastCalculation = null;
     // If an operator was just entered (no new digit yet), undo the operator
+    // and restore the left-hand operand so nothing is left dangling. The tape
+    // rewinds by exactly what that operator press appended.
     if (_shouldResetDisplay && _operator.isNotEmpty) {
+      if (_tapeUndoCount > 0 && _tapeUndoCount <= _tape.length) {
+        _tape.removeRange(_tape.length - _tapeUndoCount, _tape.length);
+      }
+      _tapeUndoCount = 0;
+      _displayValue = _previousValue;
+      _previousValue = '';
       _operator = '';
-      _shouldResetDisplay = false;
+      // If the operand was already folded into the running total, the value on
+      // screen is a result: the next digit starts a new term rather than
+      // appending to it, which would leave the tape describing a stale number.
+      _shouldResetDisplay = _lastOperatorEvaluated;
+      _lastOperatorEvaluated = false;
+      _hasDecimal = _displayValue.contains('.');
       return;
     }
     _shouldResetDisplay = false;
-    if (_displayValue.length > 1) {
+    if (_displayValue.length > 1 && _displayValue != '-0') {
       if (_displayValue[_displayValue.length - 1] == '.') {
         _hasDecimal = false;
       }
       _displayValue = _displayValue.substring(0, _displayValue.length - 1);
+      if (_displayValue == '-') _displayValue = '0';
     } else {
       _displayValue = '0';
       _hasDecimal = false;
@@ -167,7 +377,7 @@ class CalculatorLogic {
   }
 
   void toggleSign() {
-    if (_displayValue == '0' || _displayValue == 'Error') return;
+    if (_hasError || _displayValue == '0') return;
 
     if (_displayValue.startsWith('-')) {
       _displayValue = _displayValue.substring(1);
@@ -176,10 +386,23 @@ class CalculatorLogic {
     }
   }
 
-  void percentage() {
-    double value = double.tryParse(_displayValue) ?? 0;
-    value = value / 100;
-    _displayValue = value.toString();
-    _hasDecimal = true;
+  /// Loads a stored calculation back onto the display, e.g. from history.
+  ///
+  /// [expression] is the chain that produced [value]; supplying it rebuilds
+  /// the tape so the restored entry reads exactly as it did when computed,
+  /// instead of dropping the user at a bare number with no context.
+  void restore(String value, {String? expression}) {
+    clear();
+    if (value.isEmpty) return;
+    _displayValue = value;
+    _shouldResetDisplay = true;
+    _hasDecimal = value.contains('.');
+
+    if (expression == null || expression.isEmpty) return;
+    // Pushed as one token: the tape joins on spaces, so a pre-formatted chain
+    // renders identically to one built key by key.
+    _pushTape(expression);
+    _pushTape('=');
+    _pushTape(value);
   }
 }

--- a/lib/utils/finance.dart
+++ b/lib/utils/finance.dart
@@ -1,0 +1,339 @@
+/// Pure financial maths. No Flutter, no formatting — everything here is
+/// directly unit-testable and shared by the calculator screens.
+library;
+
+import 'dart:math';
+
+/// Guards runaway amortisation loops (100 years of monthly payments).
+const int _maxMonths = 1200;
+
+/// Thrown when inputs describe a loan that never gets repaid.
+class LoanNeverAmortisesError implements Exception {
+  final String message;
+  const LoanNeverAmortisesError(this.message);
+  @override
+  String toString() => message;
+}
+
+// ── EMI ──────────────────────────────────────────────────────────────────────
+
+class EmiResult {
+  /// Equated monthly instalment.
+  final double emi;
+  final double principal;
+  final double totalPayment;
+  final double totalInterest;
+  final int months;
+
+  const EmiResult({
+    required this.emi,
+    required this.principal,
+    required this.totalPayment,
+    required this.totalInterest,
+    required this.months,
+  });
+
+  /// Share of every rupee repaid that is interest, 0–1.
+  double get interestShare =>
+      totalPayment == 0 ? 0 : totalInterest / totalPayment;
+}
+
+/// EMI = P·i·(1+i)^n / ((1+i)^n − 1), with the zero-rate case handled.
+EmiResult calculateEmi({
+  required double principal,
+  required double annualRatePercent,
+  required int months,
+}) {
+  assert(principal > 0 && months > 0 && annualRatePercent >= 0);
+
+  final i = annualRatePercent / 12 / 100;
+  final double emi;
+  if (i == 0) {
+    emi = principal / months;
+  } else {
+    final growth = pow(1 + i, months).toDouble();
+    emi = principal * i * growth / (growth - 1);
+  }
+
+  final totalPayment = emi * months;
+  return EmiResult(
+    emi: emi,
+    principal: principal,
+    totalPayment: totalPayment,
+    totalInterest: totalPayment - principal,
+    months: months,
+  );
+}
+
+// ── Loan payoff with extra payments ──────────────────────────────────────────
+
+enum ExtraPaymentFrequency { monthly, yearly }
+
+class LoanYearRow {
+  final int year;
+  final double principalPaid;
+  final double interestPaid;
+  final double extraPaid;
+  final double closingBalance;
+
+  const LoanYearRow({
+    required this.year,
+    required this.principalPaid,
+    required this.interestPaid,
+    required this.extraPaid,
+    required this.closingBalance,
+  });
+}
+
+class LoanPayoffResult {
+  final double emi;
+  final double principal;
+
+  /// Months the loan would run with no extra payments.
+  final int baselineMonths;
+  final double baselineInterest;
+
+  /// Months it actually takes once the extra payments are applied.
+  final int payoffMonths;
+  final double actualInterest;
+
+  final double totalExtraPaid;
+  final List<LoanYearRow> schedule;
+
+  const LoanPayoffResult({
+    required this.emi,
+    required this.principal,
+    required this.baselineMonths,
+    required this.baselineInterest,
+    required this.payoffMonths,
+    required this.actualInterest,
+    required this.totalExtraPaid,
+    required this.schedule,
+  });
+
+  int get monthsSaved => baselineMonths - payoffMonths;
+  double get interestSaved => baselineInterest - actualInterest;
+  bool get hasExtra => totalExtraPaid > 0;
+}
+
+/// Amortises the loan month by month, applying [extraAmount] on top of the
+/// EMI, and reports how much sooner it clears.
+///
+/// The EMI itself is always the one for the *original* tenure — paying extra
+/// shortens the loan rather than reducing the instalment.
+LoanPayoffResult calculateLoanPayoff({
+  required double principal,
+  required double annualRatePercent,
+  required int months,
+  double extraAmount = 0,
+  ExtraPaymentFrequency frequency = ExtraPaymentFrequency.yearly,
+}) {
+  assert(principal > 0 && months > 0 && annualRatePercent >= 0);
+  assert(extraAmount >= 0);
+
+  final baseline = calculateEmi(
+    principal: principal,
+    annualRatePercent: annualRatePercent,
+    months: months,
+  );
+
+  final i = annualRatePercent / 12 / 100;
+  final emi = baseline.emi;
+
+  // With no extra payment an EMI always clears the loan, but a user-supplied
+  // rate change could in principle make the instalment too small.
+  if (i > 0 && emi <= principal * i && extraAmount == 0) {
+    throw const LoanNeverAmortisesError(
+      'The instalment does not cover the monthly interest.',
+    );
+  }
+
+  var balance = principal;
+  var totalInterest = 0.0;
+  var totalExtra = 0.0;
+  var month = 0;
+
+  var yearPrincipal = 0.0;
+  var yearInterest = 0.0;
+  var yearExtra = 0.0;
+  final schedule = <LoanYearRow>[];
+
+  while (balance > 0.005 && month < _maxMonths) {
+    month++;
+
+    final interest = balance * i;
+    var principalPart = emi - interest;
+    if (principalPart <= 0) {
+      throw const LoanNeverAmortisesError(
+        'The instalment does not cover the monthly interest.',
+      );
+    }
+    if (principalPart > balance) principalPart = balance;
+
+    balance -= principalPart;
+    totalInterest += interest;
+    yearInterest += interest;
+    yearPrincipal += principalPart;
+
+    // Extra payment lands after the instalment for that month.
+    if (extraAmount > 0 && balance > 0) {
+      final due = frequency == ExtraPaymentFrequency.monthly || month % 12 == 0;
+      if (due) {
+        final extra = min(extraAmount, balance);
+        balance -= extra;
+        totalExtra += extra;
+        yearExtra += extra;
+      }
+    }
+
+    if (month % 12 == 0 || balance <= 0.005) {
+      schedule.add(LoanYearRow(
+        year: (month / 12).ceil(),
+        principalPaid: yearPrincipal,
+        interestPaid: yearInterest,
+        extraPaid: yearExtra,
+        closingBalance: balance < 0.005 ? 0 : balance,
+      ));
+      yearPrincipal = 0;
+      yearInterest = 0;
+      yearExtra = 0;
+    }
+  }
+
+  return LoanPayoffResult(
+    emi: emi,
+    principal: principal,
+    baselineMonths: months,
+    baselineInterest: baseline.totalInterest,
+    payoffMonths: month,
+    actualInterest: totalInterest,
+    totalExtraPaid: totalExtra,
+    schedule: schedule,
+  );
+}
+
+// ── SIP ──────────────────────────────────────────────────────────────────────
+
+class SipYearRow {
+  final int year;
+  final double invested;
+  final double value;
+
+  const SipYearRow({
+    required this.year,
+    required this.invested,
+    required this.value,
+  });
+
+  double get gain => value - invested;
+}
+
+class SipResult {
+  final double monthly;
+  final double maturity;
+  final double invested;
+  final int months;
+  final List<SipYearRow> schedule;
+
+  const SipResult({
+    required this.monthly,
+    required this.maturity,
+    required this.invested,
+    required this.months,
+    required this.schedule,
+  });
+
+  double get gain => maturity - invested;
+
+  /// Gain as a fraction of the amount invested, 0–1+.
+  double get gainRatio => invested == 0 ? 0 : gain / invested;
+}
+
+/// Future value of a monthly SIP, contributions made at the start of each
+/// month (annuity-due): M = P · (((1+i)^n − 1) / i) · (1+i).
+SipResult calculateSip({
+  required double monthly,
+  required double annualRatePercent,
+  required double years,
+}) {
+  assert(monthly > 0 && years > 0 && annualRatePercent >= 0);
+
+  final months = (years * 12).round();
+  final i = annualRatePercent / 12 / 100;
+
+  double futureValue(int n) {
+    if (n <= 0) return 0;
+    if (i == 0) return monthly * n;
+    return monthly * ((pow(1 + i, n) - 1) / i) * (1 + i);
+  }
+
+  final schedule = <SipYearRow>[];
+  final wholeYears = (months / 12).ceil();
+  for (var y = 1; y <= wholeYears; y++) {
+    final n = min(y * 12, months);
+    schedule.add(SipYearRow(
+      year: y,
+      invested: monthly * n,
+      value: futureValue(n),
+    ));
+  }
+
+  return SipResult(
+    monthly: monthly,
+    maturity: futureValue(months),
+    invested: monthly * months,
+    months: months,
+    schedule: schedule,
+  );
+}
+
+// ── Realised return ──────────────────────────────────────────────────────────
+
+class RoiResult {
+  final double invested;
+  final double currentValue;
+  final double years;
+
+  const RoiResult({
+    required this.invested,
+    required this.currentValue,
+    required this.years,
+  });
+
+  double get profit => currentValue - invested;
+
+  /// Total return over the whole holding period, as a fraction.
+  double get absoluteReturn => invested == 0 ? 0 : profit / invested;
+
+  /// Compound annual growth rate, as a fraction. Undefined for a holding
+  /// that went to zero.
+  double get cagr {
+    if (invested <= 0 || currentValue <= 0 || years <= 0) return 0;
+    return pow(currentValue / invested, 1 / years) - 1;
+  }
+
+  bool get isLoss => profit < 0;
+}
+
+RoiResult calculateRoi({
+  required double invested,
+  required double currentValue,
+  required double years,
+}) {
+  assert(invested > 0 && years > 0);
+  return RoiResult(
+    invested: invested,
+    currentValue: currentValue,
+    years: years,
+  );
+}
+
+/// "3 yr 4 mo" / "8 mo" / "5 yr" — used for tenures and time saved.
+String formatMonths(int months) {
+  if (months <= 0) return '0 mo';
+  final years = months ~/ 12;
+  final rest = months % 12;
+  if (years == 0) return '$rest mo';
+  if (rest == 0) return '$years yr';
+  return '$years yr $rest mo';
+}

--- a/lib/utils/money.dart
+++ b/lib/utils/money.dart
@@ -1,0 +1,35 @@
+import 'package:intl/intl.dart';
+
+/// Indian digit grouping: 12,00,000 rather than 1,200,000.
+final NumberFormat _inr = NumberFormat('#,##,##0.00', 'en_IN');
+final NumberFormat _inrWhole = NumberFormat('#,##,##0', 'en_IN');
+
+/// `12,00,000.00`
+String money(num value) => _inr.format(value);
+
+/// `12,00,000` — for figures where paise are noise.
+String moneyWhole(num value) => _inrWhole.format(value);
+
+/// `₹ 12,00,000.00`
+String rupees(num value) => '₹ ${money(value)}';
+
+/// Formats a 0–1 fraction as a percentage, e.g. 0.2011 → `20.11%`.
+String percent(double fraction, {int decimals = 2}) =>
+    '${(fraction * 100).toStringAsFixed(decimals)}%';
+
+/// Durations are held as doubles, so a whole number arrives as "5.0".
+/// `5.0 → "5"`, `2.5 → "2.5"`.
+String years(Object value) {
+  final parsed = value is num ? value.toDouble() : double.tryParse('$value');
+  if (parsed == null) return '$value';
+  return parsed == parsed.roundToDouble()
+      ? parsed.toInt().toString()
+      : '$parsed';
+}
+
+/// Percentage with an explicit sign, e.g. `+150.0%` / `-12.5%`.
+String signedPercent(double fraction, {int decimals = 1}) {
+  final value = fraction * 100;
+  final sign = value >= 0 ? '+' : '';
+  return '$sign${value.toStringAsFixed(decimals)}%';
+}

--- a/lib/widgets/app_snackbar.dart
+++ b/lib/widgets/app_snackbar.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../app/layout.dart';
+import '../app/theme.dart';
+
+/// Shows a floating snack bar that clears the floating bottom nav instead of
+/// sitting on top of it.
+void showAppSnackBar(BuildContext context, String message) {
+  final palette = context.palette;
+  ScaffoldMessenger.of(context)
+    ..hideCurrentSnackBar()
+    ..showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: GoogleFonts.manrope(color: palette.onSurface),
+        ),
+        backgroundColor: palette.surfaceContainerHighest,
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, kFloatingNavReserved + 8),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+}

--- a/lib/widgets/calculator_button.dart
+++ b/lib/widgets/calculator_button.dart
@@ -11,40 +11,61 @@ class CalculatorButton extends StatelessWidget {
   final VoidCallback onPressed;
   final ButtonType type;
 
+  /// Spoken label, when the glyph alone would not read well.
+  final String? semanticLabel;
+
   const CalculatorButton({
     super.key,
     required this.text,
     required this.onPressed,
     this.type = ButtonType.number,
+    this.semanticLabel,
   });
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
+
     if (type == ButtonType.equal) {
-      return _GradientButton(text: text, onPressed: onPressed);
+      return _GradientButton(
+        text: text,
+        onPressed: onPressed,
+        semanticLabel: semanticLabel,
+      );
     }
 
-    final bg = _bgColor();
-    final fg = _fgColor();
+    final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Material(
-      color: bg,
-      borderRadius: BorderRadius.circular(999),
-      child: InkWell(
-        onTap: () {
-          HapticFeedback.lightImpact();
-          onPressed();
-        },
+    return Semantics(
+      button: true,
+      label: semanticLabel ?? text,
+      excludeSemantics: true,
+      child: Material(
+        color: _bgColor(palette),
         borderRadius: BorderRadius.circular(999),
-        splashColor: AppTheme.primary.withValues(alpha: 0.15),
-        highlightColor: Colors.white.withValues(alpha: 0.05),
-        child: Center(
-          child: Text(
-            text,
-            style: GoogleFonts.spaceGrotesk(
-              fontSize: 22,
-              fontWeight: FontWeight.w500,
-              color: fg,
+        child: InkWell(
+          onTap: () {
+            HapticFeedback.lightImpact();
+            onPressed();
+          },
+          borderRadius: BorderRadius.circular(999),
+          splashColor: palette.primary.withValues(alpha: 0.15),
+          highlightColor: (isDark ? Colors.white : Colors.black)
+              .withValues(alpha: 0.05),
+          child: Center(
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 6),
+                child: Text(
+                  text,
+                  style: GoogleFonts.spaceGrotesk(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w500,
+                    color: _fgColor(palette),
+                  ),
+                ),
+              ),
             ),
           ),
         ),
@@ -52,29 +73,29 @@ class CalculatorButton extends StatelessWidget {
     );
   }
 
-  Color _bgColor() {
+  Color _bgColor(AppPalette palette) {
     switch (type) {
       case ButtonType.number:
-        return AppTheme.btnNumber;
+        return palette.btnNumber;
       case ButtonType.operator:
-        return AppTheme.btnOperator;
+        return palette.btnOperator;
       case ButtonType.clear:
-        return AppTheme.btnClear;
+        return palette.btnClear;
       case ButtonType.function:
-        return AppTheme.btnFunction;
+        return palette.btnFunction;
       case ButtonType.equal:
-        return AppTheme.primary; // fallback, never used
+        return palette.primary; // fallback, never used
     }
   }
 
-  Color _fgColor() {
+  Color _fgColor(AppPalette palette) {
     switch (type) {
       case ButtonType.operator:
-        return AppTheme.primary;
+        return palette.primary;
       case ButtonType.clear:
-        return AppTheme.error;
+        return palette.error;
       default:
-        return AppTheme.onSurface;
+        return palette.onSurface;
     }
   }
 }
@@ -83,39 +104,50 @@ class CalculatorButton extends StatelessWidget {
 class _GradientButton extends StatelessWidget {
   final String text;
   final VoidCallback onPressed;
+  final String? semanticLabel;
 
-  const _GradientButton({required this.text, required this.onPressed});
+  const _GradientButton({
+    required this.text,
+    required this.onPressed,
+    this.semanticLabel,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        HapticFeedback.mediumImpact();
-        onPressed();
-      },
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(999),
-          gradient: const LinearGradient(
-            colors: [AppTheme.primary, AppTheme.primaryDim],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: AppTheme.primary.withValues(alpha: 0.3),
-              blurRadius: 16,
-              offset: const Offset(0, 4),
+    final palette = context.palette;
+    return Semantics(
+      button: true,
+      label: semanticLabel ?? text,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: () {
+          HapticFeedback.mediumImpact();
+          onPressed();
+        },
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(999),
+            gradient: LinearGradient(
+              colors: [palette.primary, palette.primaryDim],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
             ),
-          ],
-        ),
-        child: Center(
-          child: Text(
-            text,
-            style: GoogleFonts.spaceGrotesk(
-              fontSize: 28,
-              fontWeight: FontWeight.w700,
-              color: Colors.white,
+            boxShadow: [
+              BoxShadow(
+                color: palette.primary.withValues(alpha: 0.3),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Center(
+            child: Text(
+              text,
+              style: GoogleFonts.spaceGrotesk(
+                fontSize: 28,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
             ),
           ),
         ),

--- a/lib/widgets/finance_widgets.dart
+++ b/lib/widgets/finance_widgets.dart
@@ -1,0 +1,746 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../app/theme.dart';
+
+/// Shared chrome for the Smart Calc financial tools: hero header, input card,
+/// gradient call-to-action, result card and breakdown table.
+///
+/// Each calculator supplies its own fields and results; everything visual
+/// lives here so the screens stay about their own maths.
+
+// ── Screen shell ─────────────────────────────────────────────────────────────
+
+class FinanceScaffold extends StatelessWidget {
+  final String title;
+  final String heroSubtitle;
+  final IconData icon;
+  final List<Color> accent;
+  final GlobalKey<FormState> formKey;
+  final List<Widget> fields;
+  final VoidCallback onCalculate;
+  final String ctaLabel;
+
+  /// Attached to the first result widget so [FinanceScaffold] can scroll it
+  /// into view; null until a calculation has run.
+  final Key? resultKey;
+  final List<Widget> results;
+
+  const FinanceScaffold({
+    super.key,
+    required this.title,
+    required this.heroSubtitle,
+    required this.icon,
+    required this.accent,
+    required this.formKey,
+    required this.fields,
+    required this.onCalculate,
+    required this.results,
+    this.resultKey,
+    this.ctaLabel = 'Calculate',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    return Scaffold(
+      backgroundColor: palette.background,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_ios_new_rounded,
+              color: palette.onSurface, size: 20),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: Text(
+          title,
+          style: GoogleFonts.spaceGrotesk(
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: palette.onSurface,
+          ),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 16),
+              _Hero(
+                title: title,
+                subtitle: heroSubtitle,
+                icon: icon,
+                accent: accent,
+              ),
+              const SizedBox(height: 24),
+              Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: palette.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: Column(children: fields),
+              ),
+              const SizedBox(height: 16),
+              GradientButton(
+                label: ctaLabel,
+                colors: accent,
+                onTap: onCalculate,
+              ),
+              if (results.isNotEmpty) ...[
+                const SizedBox(height: 20),
+                ...results,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Hero extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final List<Color> accent;
+
+  const _Hero({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.accent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Center(
+      child: Column(
+        children: [
+          Container(
+            width: 72,
+            height: 72,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: accent,
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(icon, color: Colors.white, size: 34),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            title,
+            style: GoogleFonts.spaceGrotesk(
+              fontSize: 20,
+              fontWeight: FontWeight.w600,
+              color: palette.onSurface,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.spaceGrotesk(
+              fontSize: 13,
+              color: palette.onSurfaceVariant,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Inputs ───────────────────────────────────────────────────────────────────
+
+class MoneyField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final String hint;
+  final String? prefix;
+  final String? suffix;
+  final bool allowDecimal;
+  final TextInputAction textInputAction;
+  final ValueChanged<String>? onSubmitted;
+
+  /// Extra validation on top of "must be a positive number".
+  final String? Function(double value)? extraValidator;
+
+  const MoneyField({
+    super.key,
+    required this.controller,
+    required this.label,
+    required this.hint,
+    this.prefix,
+    this.suffix,
+    this.allowDecimal = false,
+    this.textInputAction = TextInputAction.next,
+    this.onSubmitted,
+    this.extraValidator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return TextFormField(
+      controller: controller,
+      keyboardType: TextInputType.numberWithOptions(decimal: allowDecimal),
+      textInputAction: textInputAction,
+      onFieldSubmitted: onSubmitted,
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(
+            RegExp(allowDecimal ? r'[\d.]' : r'\d')),
+      ],
+      style: GoogleFonts.spaceGrotesk(color: palette.onSurface, fontSize: 15),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        prefixText: prefix != null ? '$prefix  ' : null,
+        suffixText: suffix,
+        prefixStyle:
+            GoogleFonts.manrope(color: palette.onSurfaceVariant, fontSize: 15),
+        suffixStyle:
+            GoogleFonts.manrope(color: palette.onSurfaceVariant, fontSize: 13),
+      ),
+      validator: (v) {
+        if (v == null || v.isEmpty) return 'Required';
+        final value = double.tryParse(v.replaceAll(',', ''));
+        if (value == null || value <= 0) return 'Enter a valid positive number';
+        return extraValidator?.call(value);
+      },
+    );
+  }
+}
+
+/// Optional numeric field — blank is allowed and means "none".
+class OptionalMoneyField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final String hint;
+  final String? prefix;
+
+  const OptionalMoneyField({
+    super.key,
+    required this.controller,
+    required this.label,
+    required this.hint,
+    this.prefix,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return TextFormField(
+      controller: controller,
+      keyboardType: TextInputType.number,
+      textInputAction: TextInputAction.done,
+      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'\d'))],
+      style: GoogleFonts.spaceGrotesk(color: palette.onSurface, fontSize: 15),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        prefixText: prefix != null ? '$prefix  ' : null,
+        prefixStyle:
+            GoogleFonts.manrope(color: palette.onSurfaceVariant, fontSize: 15),
+      ),
+      validator: (v) {
+        if (v == null || v.isEmpty) return null;
+        final value = double.tryParse(v.replaceAll(',', ''));
+        if (value == null || value < 0) return 'Enter a valid amount';
+        return null;
+      },
+    );
+  }
+}
+
+/// Pill selector used for compounding frequency, payment frequency, modes.
+class SegmentedSelector<T> extends StatelessWidget {
+  final String? label;
+  final List<({String label, T value})> options;
+  final T selected;
+  final ValueChanged<T> onChanged;
+
+  const SegmentedSelector({
+    super.key,
+    required this.options,
+    required this.selected,
+    required this.onChanged,
+    this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (label != null) ...[
+          Text(
+            label!,
+            style: GoogleFonts.manrope(
+                fontSize: 12, color: palette.onSurfaceVariant),
+          ),
+          const SizedBox(height: 8),
+        ],
+        Container(
+          padding: const EdgeInsets.all(4),
+          decoration: BoxDecoration(
+            color: palette.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Row(
+            children: options.map((option) {
+              final isActive = option.value == selected;
+              return Expanded(
+                child: Semantics(
+                  button: true,
+                  selected: isActive,
+                  child: GestureDetector(
+                    onTap: () => onChanged(option.value),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      decoration: BoxDecoration(
+                        gradient: isActive
+                            ? LinearGradient(
+                                colors: [palette.primary, palette.primaryDim],
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                              )
+                            : null,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Center(
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Text(
+                            option.label,
+                            style: GoogleFonts.manrope(
+                              fontSize: 11,
+                              fontWeight:
+                                  isActive ? FontWeight.w700 : FontWeight.w400,
+                              color: isActive
+                                  ? Colors.white
+                                  : palette.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class GradientButton extends StatelessWidget {
+  final String label;
+  final List<Color> colors;
+  final VoidCallback onTap;
+
+  const GradientButton({
+    super.key,
+    required this.label,
+    required this.colors,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          height: 56,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: colors,
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+            ),
+            borderRadius: BorderRadius.circular(999),
+            boxShadow: [
+              BoxShadow(
+                color: colors.first.withValues(alpha: 0.3),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Center(
+            child: Text(
+              '$label  →',
+              style: GoogleFonts.spaceGrotesk(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Results ──────────────────────────────────────────────────────────────────
+
+/// The headline answer, with up to four supporting stats beneath it.
+class HeadlineResult extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color? valueColor;
+  final List<({String label, String value, Color? color})> stats;
+  final String? footnote;
+
+  const HeadlineResult({
+    super.key,
+    required this.label,
+    required this.value,
+    this.stats = const [],
+    this.valueColor,
+    this.footnote,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final accent = valueColor ?? palette.primary;
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: isDark
+            ? const Color(0xFF13121F)
+            : palette.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: accent.withValues(alpha: 0.16)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.manrope(
+                fontSize: 12, color: palette.onSurfaceVariant),
+          ),
+          const SizedBox(height: 4),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              value,
+              style: GoogleFonts.spaceGrotesk(
+                fontSize: 32,
+                fontWeight: FontWeight.w700,
+                color: accent,
+                letterSpacing: -0.5,
+              ),
+            ),
+          ),
+          if (stats.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            for (var row = 0; row < stats.length; row += 2) ...[
+              if (row > 0) const SizedBox(height: 8),
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    StatChip(
+                      label: stats[row].label,
+                      value: stats[row].value,
+                      color: stats[row].color ?? palette.onSurfaceVariant,
+                    ),
+                    if (row + 1 < stats.length) ...[
+                      const SizedBox(width: 8),
+                      StatChip(
+                        label: stats[row + 1].label,
+                        value: stats[row + 1].value,
+                        color: stats[row + 1].color ?? palette.onSurfaceVariant,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ],
+          if (footnote != null) ...[
+            const SizedBox(height: 12),
+            Center(
+              child: Text(
+                footnote!,
+                textAlign: TextAlign.center,
+                style: GoogleFonts.manrope(
+                    fontSize: 12, color: palette.onSurfaceVariant),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class StatChip extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color color;
+
+  const StatChip({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: palette.surfaceContainerHigh,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label,
+                style: GoogleFonts.manrope(
+                    fontSize: 10, color: palette.onSurfaceVariant)),
+            const SizedBox(height: 2),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.centerLeft,
+              child: Text(
+                value,
+                style: GoogleFonts.spaceGrotesk(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: color,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Horizontal bar showing how a total splits between two parts.
+class SplitBar extends StatelessWidget {
+  final String leftLabel;
+  final String rightLabel;
+  final double leftFraction;
+  final Color leftColor;
+  final Color rightColor;
+
+  const SplitBar({
+    super.key,
+    required this.leftLabel,
+    required this.rightLabel,
+    required this.leftFraction,
+    required this.leftColor,
+    required this.rightColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final left = leftFraction.clamp(0.0, 1.0);
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: palette.surfaceContainer,
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: SizedBox(
+              height: 12,
+              child: Row(
+                // The height is already bounded at 12, so stretch is safe here
+                // and is what gives the bars a height at all — the Row's
+                // default centre alignment would collapse them to nothing.
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    flex: (left * 1000).round().clamp(1, 1000),
+                    child: ColoredBox(color: leftColor),
+                  ),
+                  Expanded(
+                    flex: ((1 - left) * 1000).round().clamp(1, 1000),
+                    child: ColoredBox(color: rightColor),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              _Legend(color: leftColor, text: leftLabel),
+              const Spacer(),
+              _Legend(color: rightColor, text: rightLabel),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Legend extends StatelessWidget {
+  final Color color;
+  final String text;
+
+  const _Legend({required this.color, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          text,
+          style: GoogleFonts.manrope(
+              fontSize: 11, color: palette.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+/// Year-by-year table. [columns] are the header labels; [rows] must match.
+class BreakdownTable extends StatelessWidget {
+  final String title;
+  final List<({String label, int flex})> columns;
+  final List<List<String>> rows;
+
+  /// Column index tinted with the accent colour, if any.
+  final int? accentColumn;
+  final Color? accentColor;
+  final String? footnote;
+
+  const BreakdownTable({
+    super.key,
+    required this.title,
+    required this.columns,
+    required this.rows,
+    this.accentColumn,
+    this.accentColor,
+    this.footnote,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: palette.surfaceContainer,
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: GoogleFonts.spaceGrotesk(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: palette.onSurface,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              for (final column in columns)
+                _cell(context, column.label,
+                    flex: column.flex, isHeader: true),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final row in rows)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Row(
+                children: [
+                  for (var i = 0; i < row.length; i++)
+                    _cell(
+                      context,
+                      row[i],
+                      flex: columns[i].flex,
+                      color: i == accentColumn ? accentColor : null,
+                    ),
+                ],
+              ),
+            ),
+          if (footnote != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                footnote!,
+                style: GoogleFonts.manrope(
+                    fontSize: 11, color: palette.onSurfaceVariant),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _cell(BuildContext context, String text,
+      {required int flex, bool isHeader = false, Color? color}) {
+    final palette = context.palette;
+    return Expanded(
+      flex: flex,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.centerLeft,
+        child: Text(
+          text,
+          style: GoogleFonts.spaceGrotesk(
+            fontSize: isHeader ? 12 : 13,
+            fontWeight: isHeader ? FontWeight.w700 : FontWeight.w400,
+            color: color ??
+                (isHeader ? palette.onSurfaceVariant : palette.onSurface),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/calculator_logic_test.dart
+++ b/test/calculator_logic_test.dart
@@ -68,14 +68,6 @@ void main() {
       expect(calculator.displayValue, '5');
     });
 
-    test('should handle division by zero', () {
-      calculator.inputNumber('5');
-      calculator.inputOperator('÷');
-      calculator.inputNumber('0');
-      calculator.calculate();
-      expect(calculator.displayValue, 'Error');
-    });
-
     test('should clear display', () {
       calculator.inputNumber('5');
       calculator.inputNumber('3');
@@ -99,13 +91,6 @@ void main() {
       expect(calculator.displayValue, '5');
     });
 
-    test('should calculate percentage', () {
-      calculator.inputNumber('5');
-      calculator.inputNumber('0');
-      calculator.percentage();
-      expect(calculator.displayValue, '0.5');
-    });
-
     test('should handle chained operations', () {
       calculator.inputNumber('5');
       calculator.inputOperator('+');
@@ -114,6 +99,325 @@ void main() {
       calculator.inputNumber('2');
       calculator.calculate();
       expect(calculator.displayValue, '16');
+    });
+
+    test('keeps the completed expression on screen after =', () {
+      calculator.inputNumber('7');
+      calculator.inputOperator('+');
+      calculator.inputNumber('8');
+      calculator.calculate();
+      expect(calculator.displayValue, '15');
+      expect(calculator.expression, '7 + 8 =');
+    });
+
+    group('error handling', () {
+      test('division by zero reports an error', () {
+        calculator.inputNumber('5');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('0');
+        calculator.calculate();
+        expect(calculator.displayValue, 'Error');
+        expect(calculator.hasError, isTrue);
+      });
+
+      test('an operator applied to an error is refused, not coerced to 0', () {
+        calculator.inputNumber('5');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('0');
+        calculator.calculate();
+
+        calculator.inputOperator('+');
+        // The operator is dropped: no pending "Error + …" is built up.
+        expect(calculator.displayValue, 'Error');
+        expect(calculator.hasError, isTrue);
+        expect(calculator.currentOperator, isEmpty);
+
+        // The next digit starts a clean entry instead of continuing the
+        // broken one, which used to evaluate "Error + 5" as 0 + 5.
+        calculator.inputNumber('5');
+        calculator.calculate();
+        expect(calculator.displayValue, '5');
+        expect(calculator.expression, isEmpty);
+        expect(calculator.lastCalculation, isNull);
+      });
+
+      test('typing a digit recovers from an error', () {
+        calculator.inputNumber('5');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('0');
+        calculator.calculate();
+
+        calculator.inputNumber('7');
+        expect(calculator.displayValue, '7');
+        expect(calculator.hasError, isFalse);
+      });
+
+      test('clear recovers from an error', () {
+        calculator.inputNumber('5');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('0');
+        calculator.calculate();
+        calculator.clear();
+        expect(calculator.displayValue, '0');
+        expect(calculator.hasError, isFalse);
+      });
+
+      test('an errored calculation is not offered for history', () {
+        calculator.inputNumber('5');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('0');
+        calculator.calculate();
+        expect(calculator.lastCalculation, isNull);
+      });
+    });
+
+    group('history hand-off', () {
+      test('exposes the expression and result of the last =', () {
+        calculator.inputNumber('7');
+        calculator.inputOperator('+');
+        calculator.inputNumber('8');
+        calculator.calculate();
+
+        final done = calculator.lastCalculation;
+        expect(done, isNotNull);
+        expect(done!.expression, '7 + 8');
+        expect(done.result, '15');
+      });
+
+      test('is cleared once new input starts', () {
+        calculator.inputNumber('2');
+        calculator.inputOperator('+');
+        calculator.inputNumber('2');
+        calculator.calculate();
+        expect(calculator.lastCalculation, isNotNull);
+
+        calculator.inputNumber('9');
+        expect(calculator.lastCalculation, isNull);
+      });
+    });
+
+    group('formatting', () {
+      test('rounds long decimals but keeps full precision available', () {
+        calculator.inputNumber('1');
+        calculator.inputNumber('0');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('3');
+        calculator.calculate();
+
+        expect(calculator.displayValue, '3.3333');
+        expect(calculator.isResultTruncated, isTrue);
+        expect(calculator.fullResult, startsWith('3.3333333333'));
+      });
+
+      test('uses scientific notation above the readable range', () {
+        calculator.inputNumber('9');
+        for (var i = 0; i < 14; i++) {
+          calculator.inputNumber('9');
+        }
+        calculator.inputOperator('×');
+        calculator.inputNumber('9');
+        calculator.calculate();
+
+        expect(calculator.displayValue, contains('e+'));
+      });
+
+      test('an exact result has no trailing decimals', () {
+        calculator.inputNumber('4');
+        calculator.inputOperator('÷');
+        calculator.inputNumber('2');
+        calculator.calculate();
+        expect(calculator.displayValue, '2');
+        expect(calculator.isResultTruncated, isFalse);
+      });
+    });
+
+    group('running tape', () {
+      /// Enters `a op b op c …`, mirroring how a long chain is typed.
+      void enterChain(List<String> tokens) {
+        for (final token in tokens) {
+          if ('0123456789'.contains(token[0])) {
+            for (final digit in token.split('')) {
+              calculator.inputNumber(digit);
+            }
+          } else {
+            calculator.inputOperator(token);
+          }
+        }
+      }
+
+      test('is empty until the first operator', () {
+        calculator.inputNumber('7');
+        expect(calculator.tape, isEmpty);
+      });
+
+      test('keeps every step of a long chain, not just the last two', () {
+        enterChain(['12', '+', '8', '−', '5', '×', '3', '÷', '9', '+', '4']);
+        calculator.calculate();
+
+        // The running total collapses to a single number; the tape does not.
+        expect(calculator.tape, '12 + 8 − 5 × 3 ÷ 9 + 4 = 9');
+        expect(calculator.displayValue, '9');
+      });
+
+      test('records ten operands in order', () {
+        enterChain([
+          '1', '+', '2', '+', '3', '+', '4', '+', '5', //
+          '+', '6', '+', '7', '+', '8', '+', '9', '+', '10',
+        ]);
+        calculator.calculate();
+        expect(calculator.tape, '1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 = 55');
+      });
+
+      test('continues from the result when an operator follows =', () {
+        enterChain(['2', '+', '3']);
+        calculator.calculate();
+        calculator.inputOperator('×');
+        calculator.inputNumber('4');
+        calculator.calculate();
+
+        expect(calculator.tape, '2 + 3 = 5 × 4 = 20');
+      });
+
+      test('starts a new line when a fresh number follows =', () {
+        enterChain(['2', '+', '3']);
+        calculator.calculate();
+        calculator.inputNumber('9');
+        calculator.inputOperator('+');
+        calculator.inputNumber('1');
+        calculator.calculate();
+
+        expect(calculator.tape, '2 + 3 = 5\n9 + 1 = 10');
+      });
+
+      test('swapping a mis-typed operator does not duplicate the term', () {
+        enterChain(['6', '+']);
+        calculator.inputOperator('×');
+        calculator.inputNumber('7');
+        calculator.calculate();
+
+        expect(calculator.tape, '6 × 7 = 42');
+      });
+
+      test('backspacing an unevaluated operator drops its operand too', () {
+        enterChain(['7', '+']);
+        calculator.backspace();
+        expect(calculator.tape, isEmpty);
+        expect(calculator.displayValue, '7');
+      });
+
+      test('backspacing a chained operator keeps the spent operand', () {
+        enterChain(['4', '+', '5', '−']);
+        calculator.backspace();
+
+        // "5" was already folded into the running total, so only the dangling
+        // "−" comes back off the tape.
+        expect(calculator.tape, '4 + 5');
+        expect(calculator.displayValue, '9');
+        expect(calculator.currentOperator, isEmpty);
+      });
+
+      test('survives = and CE, and is cleared only by C', () {
+        enterChain(['3', '+', '4']);
+        calculator.calculate();
+        expect(calculator.tape, isNotEmpty);
+
+        calculator.clearEntry();
+        expect(calculator.tape, '3 + 4 = 7');
+
+        calculator.clear();
+        expect(calculator.tape, isEmpty);
+      });
+
+      test('shows where a chain failed', () {
+        enterChain(['8', '÷', '0']);
+        calculator.calculate();
+        expect(calculator.tape, '8 ÷ 0 = Error');
+      });
+    });
+
+    test('caps typed input at maxInputDigits', () {
+      for (var i = 0; i < CalculatorLogic.maxInputDigits + 10; i++) {
+        calculator.inputNumber('9');
+      }
+      expect(calculator.displayValue.length, CalculatorLogic.maxInputDigits);
+    });
+
+    test('backspacing a just-entered operator restores the operand', () {
+      calculator.inputNumber('7');
+      calculator.inputOperator('+');
+      calculator.backspace();
+      expect(calculator.displayValue, '7');
+      expect(calculator.currentOperator, isEmpty);
+      expect(calculator.previousValue, isEmpty);
+    });
+
+    group('restore', () {
+      test('loads a stored value onto the display', () {
+        calculator.restore('152730.06');
+        expect(calculator.displayValue, '152730.06');
+
+        // The restored value behaves as a completed result: typing replaces it.
+        calculator.inputNumber('4');
+        expect(calculator.displayValue, '4');
+      });
+
+      test('rebuilds the tape from the stored working', () {
+        calculator.restore('9', expression: '12 + 8 − 5 × 3 ÷ 9 + 4');
+        expect(calculator.tape, '12 + 8 − 5 × 3 ÷ 9 + 4 = 9');
+        expect(calculator.displayValue, '9');
+      });
+
+      test('a restored calculation can be carried on', () {
+        calculator.restore('15', expression: '7 + 8');
+        calculator.inputOperator('×');
+        calculator.inputNumber('2');
+        calculator.calculate();
+
+        expect(calculator.tape, '7 + 8 = 15 × 2 = 30');
+        expect(calculator.displayValue, '30');
+      });
+
+      test('starts a new line when a fresh number follows a restore', () {
+        calculator.restore('15', expression: '7 + 8');
+        calculator.inputNumber('4');
+        calculator.inputOperator('+');
+        calculator.inputNumber('1');
+        calculator.calculate();
+
+        expect(calculator.tape, '7 + 8 = 15\n4 + 1 = 5');
+      });
+
+      test('without working it still restores the bare value', () {
+        calculator.restore('42');
+        expect(calculator.tape, isEmpty);
+        expect(calculator.displayValue, '42');
+      });
+    });
+
+    group('what gets persisted', () {
+      test('stores the whole chain, not the running total', () {
+        for (final token in ['1', '+', '2', '+', '3']) {
+          if (token == '+') {
+            calculator.inputOperator('+');
+          } else {
+            calculator.inputNumber(token);
+          }
+        }
+        calculator.calculate();
+
+        // Previously this recorded "3 + 3", the running total plus the last
+        // operand, which read back as a different sum entirely.
+        expect(calculator.lastCalculation!.expression, '1 + 2 + 3');
+        expect(calculator.lastCalculation!.result, '6');
+      });
+
+      test('a single step is unchanged', () {
+        calculator.inputNumber('7');
+        calculator.inputOperator('+');
+        calculator.inputNumber('8');
+        calculator.calculate();
+        expect(calculator.lastCalculation!.expression, '7 + 8');
+      });
     });
   });
 }

--- a/test/finance_test.dart
+++ b/test/finance_test.dart
@@ -1,0 +1,253 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:life_mathematics/utils/finance.dart';
+import 'package:life_mathematics/utils/money.dart';
+
+void main() {
+  group('EMI', () {
+    test('matches the standard bank figure for ₹10L @ 9% over 5 years', () {
+      final result = calculateEmi(
+        principal: 1000000,
+        annualRatePercent: 9,
+        months: 60,
+      );
+
+      // P·i·(1+i)^n / ((1+i)^n − 1) with i = 0.0075, n = 60.
+      expect(result.emi, closeTo(20758.36, 0.01));
+      expect(result.totalPayment, closeTo(1245501.40, 0.5));
+      expect(result.totalInterest, closeTo(245501.40, 0.5));
+      expect(result.months, 60);
+    });
+
+    test('a 20-year home loan at 8.5%', () {
+      final result = calculateEmi(
+        principal: 5000000,
+        annualRatePercent: 8.5,
+        months: 240,
+      );
+      expect(result.emi, closeTo(43391.16, 0.5));
+    });
+
+    test('a zero-rate loan is just the principal split evenly', () {
+      final result = calculateEmi(
+        principal: 120000,
+        annualRatePercent: 0,
+        months: 12,
+      );
+      expect(result.emi, closeTo(10000, 0.001));
+      expect(result.totalInterest, closeTo(0, 0.001));
+    });
+
+    test('interest share is the fraction of repayments that is interest', () {
+      final result = calculateEmi(
+        principal: 1000000,
+        annualRatePercent: 9,
+        months: 60,
+      );
+      expect(result.interestShare, closeTo(0.1971, 0.001));
+    });
+  });
+
+  group('loan payoff', () {
+    test('with no extra payment it runs the full tenure', () {
+      final result = calculateLoanPayoff(
+        principal: 1000000,
+        annualRatePercent: 9,
+        months: 60,
+      );
+
+      expect(result.payoffMonths, 60);
+      expect(result.monthsSaved, 0);
+      expect(result.interestSaved, closeTo(0, 1));
+      expect(result.hasExtra, isFalse);
+      // Amortising month by month must agree with the closed-form total.
+      expect(result.actualInterest, closeTo(result.baselineInterest, 1));
+    });
+
+    test('an extra yearly payment clears the loan early', () {
+      final result = calculateLoanPayoff(
+        principal: 1000000,
+        annualRatePercent: 9,
+        months: 60,
+        extraAmount: 50000,
+        frequency: ExtraPaymentFrequency.yearly,
+      );
+
+      expect(result.payoffMonths, lessThan(60));
+      expect(result.monthsSaved, greaterThan(0));
+      expect(result.interestSaved, greaterThan(0));
+      expect(result.totalExtraPaid, greaterThan(0));
+    });
+
+    test('paying extra every month clears it sooner than every year', () {
+      LoanPayoffResult run(ExtraPaymentFrequency frequency, double amount) =>
+          calculateLoanPayoff(
+            principal: 1000000,
+            annualRatePercent: 9,
+            months: 60,
+            extraAmount: amount,
+            frequency: frequency,
+          );
+
+      // ₹5,000 a month is ₹60,000 a year, so it must beat ₹60,000 once a year.
+      final monthly = run(ExtraPaymentFrequency.monthly, 5000);
+      final yearly = run(ExtraPaymentFrequency.yearly, 60000);
+
+      expect(monthly.payoffMonths, lessThanOrEqualTo(yearly.payoffMonths));
+      expect(monthly.actualInterest, lessThan(yearly.actualInterest));
+    });
+
+    test('the balance actually reaches zero', () {
+      final result = calculateLoanPayoff(
+        principal: 2500000,
+        annualRatePercent: 8.5,
+        months: 240,
+        extraAmount: 100000,
+      );
+      expect(result.schedule.last.closingBalance, closeTo(0, 0.01));
+    });
+
+    test('principal repaid plus extra equals the loan', () {
+      final result = calculateLoanPayoff(
+        principal: 1000000,
+        annualRatePercent: 9,
+        months: 60,
+        extraAmount: 50000,
+      );
+
+      final repaid = result.schedule.fold<double>(
+        0,
+        (sum, row) => sum + row.principalPaid + row.extraPaid,
+      );
+      expect(repaid, closeTo(1000000, 1));
+    });
+
+    test('a big enough extra payment ends it in the first year', () {
+      final result = calculateLoanPayoff(
+        principal: 500000,
+        annualRatePercent: 10,
+        months: 120,
+        extraAmount: 200000,
+        frequency: ExtraPaymentFrequency.monthly,
+      );
+      expect(result.payoffMonths, lessThanOrEqualTo(12));
+    });
+  });
+
+  group('SIP', () {
+    test('₹10,000/mo at 12% for 10 years', () {
+      final result = calculateSip(
+        monthly: 10000,
+        annualRatePercent: 12,
+        years: 10,
+      );
+
+      // Annuity due: P·(((1+i)^n − 1)/i)·(1+i), i = 0.01, n = 120.
+      expect(result.maturity, closeTo(2323391, 50));
+      expect(result.invested, closeTo(1200000, 0.01));
+      expect(result.gain, closeTo(1123391, 50));
+      expect(result.months, 120);
+    });
+
+    test('a zero-return SIP returns exactly what went in', () {
+      final result = calculateSip(
+        monthly: 5000,
+        annualRatePercent: 0,
+        years: 3,
+      );
+      expect(result.maturity, closeTo(180000, 0.01));
+      expect(result.gain, closeTo(0, 0.01));
+    });
+
+    test('the schedule ends at the maturity value', () {
+      final result = calculateSip(
+        monthly: 10000,
+        annualRatePercent: 12,
+        years: 10,
+      );
+      expect(result.schedule.length, 10);
+      expect(result.schedule.last.value, closeTo(result.maturity, 0.01));
+      expect(result.schedule.last.invested, closeTo(result.invested, 0.01));
+    });
+
+    test('value never falls below the amount invested at a positive rate', () {
+      final result = calculateSip(
+        monthly: 2000,
+        annualRatePercent: 8,
+        years: 5,
+      );
+      for (final row in result.schedule) {
+        expect(row.value, greaterThanOrEqualTo(row.invested));
+      }
+    });
+  });
+
+  group('realised return', () {
+    test('₹1L growing to ₹2.5L over 5 years is 20.11% CAGR', () {
+      final result = calculateRoi(
+        invested: 100000,
+        currentValue: 250000,
+        years: 5,
+      );
+
+      expect(result.cagr, closeTo(0.201126, 0.00001));
+      expect(result.absoluteReturn, closeTo(1.5, 0.00001));
+      expect(result.profit, closeTo(150000, 0.01));
+      expect(result.isLoss, isFalse);
+    });
+
+    test('a doubling in one year is 100% CAGR', () {
+      final result =
+          calculateRoi(invested: 50000, currentValue: 100000, years: 1);
+      expect(result.cagr, closeTo(1.0, 0.00001));
+    });
+
+    test('a loss reports negative return', () {
+      final result =
+          calculateRoi(invested: 100000, currentValue: 60000, years: 2);
+
+      expect(result.isLoss, isTrue);
+      expect(result.profit, closeTo(-40000, 0.01));
+      expect(result.absoluteReturn, closeTo(-0.4, 0.00001));
+      expect(result.cagr, lessThan(0));
+    });
+
+    test('no change is zero return', () {
+      final result =
+          calculateRoi(invested: 100000, currentValue: 100000, years: 7);
+      expect(result.cagr, closeTo(0, 0.00001));
+      expect(result.absoluteReturn, closeTo(0, 0.00001));
+    });
+  });
+
+  group('formatMonths', () {
+    test('renders years and months', () {
+      expect(formatMonths(0), '0 mo');
+      expect(formatMonths(8), '8 mo');
+      expect(formatMonths(12), '1 yr');
+      expect(formatMonths(40), '3 yr 4 mo');
+      expect(formatMonths(60), '5 yr');
+    });
+  });
+
+  group('money formatting', () {
+    test('uses Indian digit grouping', () {
+      expect(money(1200000), '12,00,000.00');
+      expect(money(100000), '1,00,000.00');
+      expect(money(999), '999.00');
+      expect(moneyWhole(12345678), '1,23,45,678');
+    });
+
+    test('percentages', () {
+      expect(percent(0.201126), '20.11%');
+      expect(signedPercent(1.5), '+150.0%');
+      expect(signedPercent(-0.4), '-40.0%');
+    });
+
+    test('whole-number durations drop the trailing .0', () {
+      expect(years(5.0), '5');
+      expect(years(2.5), '2.5');
+      expect(years('10'), '10');
+      expect(years('7.5'), '7.5');
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,13 +4,41 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:life_mathematics/main.dart';
 
 void main() {
-  testWidgets('App renders with navigation structure', (WidgetTester tester) async {
+  testWidgets('App renders with navigation structure',
+      (WidgetTester tester) async {
     await tester.pumpWidget(const LifeMathematicsApp(isDarkMode: false));
     await tester.pump();
 
     expect(find.text('Life Mathematics'), findsOneWidget);
+    // Every tab stays mounted inside the IndexedStack, so match on the nav
+    // labels rather than icons (History's empty state reuses the same icon).
+    expect(find.text('Calculator'), findsOneWidget);
+    expect(find.text('Smart Calc'), findsOneWidget);
+    expect(find.text('History'), findsOneWidget);
     expect(find.byIcon(Icons.calculate_outlined), findsOneWidget);
-    expect(find.byIcon(Icons.auto_awesome_outlined), findsOneWidget);
-    expect(find.byIcon(Icons.history_outlined), findsOneWidget);
+  });
+
+  testWidgets('the calculation survives leaving and returning to the tab',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const LifeMathematicsApp(isDarkMode: true));
+    await tester.pump();
+
+    await tester.tap(find.bySemanticsLabel('7'));
+    await tester.tap(find.bySemanticsLabel('Add'));
+    await tester.tap(find.bySemanticsLabel('8'));
+    await tester.tap(find.bySemanticsLabel('Equals'));
+    await tester.pump();
+
+    expect(find.text('15'), findsOneWidget);
+
+    // Leave for Smart Calc and come back.
+    await tester.tap(find.text('Smart Calc'));
+    await tester.pump();
+    await tester.tap(find.text('Calculator'));
+    await tester.pump();
+
+    // Previously the state was rebuilt from scratch and this showed '0'.
+    expect(find.text('15'), findsOneWidget);
+    expect(find.text('7 + 8 ='), findsOneWidget);
   });
 }


### PR DESCRIPTION
Adds three financial calculators, a running calculation tape, and fixes the defects found while driving the app on an emulator.

## New calculators

- **EMI** — amount/rate/tenure → monthly instalment, total interest, and a principal-vs-interest split bar.
- **Loan Payoff** — applies an extra payment on top of the EMI and amortises month by month to show how much sooner the loan clears and how much interest that saves, with a year-by-year balance table.
- **Investment Returns** — SIP projection (annuity-due) and realised CAGR on an existing holding.

The maths lives in `lib/utils/finance.dart` as pure functions with no Flutter dependency, so it is directly testable.

## Running tape

Chained arithmetic collapses to a running total, so a long calculation lost every step but the last. A third display line now records each operand and operator since the last `C`, survives `=` and `CE`, and scrolls back.

## History

- Entries were stored with an **empty result** — every row read `7 + 8 =` with no answer. The save now runs *after* `calculate()`.
- The stored expression was the running total plus the final operand, so `1 + 2 + 3 =` was recorded as `3 + 3`. It now stores the whole chain.
- Restoring an entry rebuilds the tape, not just the number.
- Tap a row to load it back into the calculator.

## Fixes

| Fix | Cause |
|---|---|
| Nav bar floated mid-screen on scrolling tabs | `Stack` shrink-wrapped its child; now `StackFit.expand` |
| Switching tabs discarded the calculation | Screens were swapped out; now `IndexedStack` |
| Light theme was inert | Every widget hardcoded the dark palette; colours now resolve through an `AppPalette` `ThemeExtension` |
| `Error + 5` silently returned `5` | `Error` was coerced to `0` |
| Divide-by-zero saved to history as valid | Save ran before evaluation |
| Results past 1e15 leaked Dart formatting | Now deliberate scientific notation; input capped at 15 digits |
| Landscape overflowed by 65px | Locked to portrait; display lines also scale |
| Compound Interest appeared to do nothing | Did not scroll to its result |
| White splash before a dark app | Launch background was `@android:color/white` |
| Pinned rows indistinguishable, duplicated timestamps, truncated amounts | History card layout |

## Verification

- `flutter analyze` clean.
- Tests **15 → 66**. Finance maths checked against published bank/SIP figures (₹10L @ 9% / 5 yr → ₹20,758.36; ₹10k/mo @ 12% / 10 yr → ₹23,23,391; ₹1L → ₹2.5L / 5 yr → 20.11% CAGR) plus invariants: principal repaid + extra equals the loan, month-by-month amortisation agrees with the closed-form total, balance reaches zero.
- Driven end-to-end on a Pixel emulator, then re-verified on a fresh instance at a different resolution (1080x2400) with an empty database. No exceptions or overflow banners.

## Notes

- Money now uses **Indian digit grouping** (`₹12,00,000.00`). The older Compound Interest screen still uses western grouping — one line to align, not done here.
- `AndroidManifest.xml` gains `android:screenOrientation="portrait"`.
- History rows written before the schema change render as `9 + 9 = ?`; the result was never stored, so there is nothing to recover.
- Web still has no `sqflite` implementation. History now shows an error state there instead of hanging forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
